### PR TITLE
Attributes, Centralized Objectives, Working XSD, etc.

### DIFF
--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -248,6 +248,21 @@ The following meta data attribute and elements are at the course level and  desc
 
 <table border="1" cellspacing="0" cellpadding="0">
   <tr>
+    <td colspan="2" valign="top"><h3>id</h3></td>
+  </tr>
+  <tr>
+    <td width="168" valign="top"><p><strong>Required</strong>: Yes<br />
+        <strong>Data type</strong>: IRI</p>
+    </td>
+    <td width="811" valign="top"><p><strong>Description</strong>:<br />
+      A globally unique IRI (Internationalized Resource Identifier per RFC 3987) for the course.  Used to explicitly identify the course instance.</p>
+      <p><strong>Value space: </strong><br />
+        Values defined by course designer<br />
+        <strong>Sample value: </strong><br />
+         &lt;course id="<span>http</span>://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/course&gt;<br/></p>
+    </td>
+  </tr>
+  <tr>
     <td colspan="2" valign="top"><h3>title</h3></td>
   </tr>
   <tr>
@@ -257,7 +272,7 @@ The following meta data attribute and elements are at the course level and  desc
       langstring</p>
     </td>
     <td width="811" valign="top"><p><strong>Description:</strong><br />
-      A descriptive title that identifies the course<br />
+      A descriptive title that identifies the course.<br />
       </p>
       <p><strong>Value space:</strong><br />
         Values defined by course designer<br />
@@ -291,21 +306,6 @@ The following meta data attribute and elements are at the course level and  desc
     &lt;/description&gt;<br/>  
     
         </p>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2" valign="top"><h3>id</h3></td>
-  </tr>
-  <tr>
-    <td width="168" valign="top"><p><strong>Required</strong>: Yes<br />
-        <strong>Data</strong> type: IRI</p>
-    </td>
-    <td width="811" valign="top"><p><strong>Description</strong>:<br />
-      A globally unique IRI (Internationalized Resource Identifier per RFC 3987) for the course.  Used to explicitly identify the course instance.</p>
-      <p><strong>Value space: </strong><br />
-        Values defined by course designer<br />
-        <strong>Sample value: </strong><br />
-         &lt;course id="http://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/course&gt;<br/></p>
     </td>
   </tr>
 </table>
@@ -349,10 +349,12 @@ The data in this section is used for the block structures with group AU’s.  A 
       <strong>Value space</strong>:<br />
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
-    &lt;description&gt;<br/>
-    &nbsp;&nbsp; &lt;langstring lang="en-US"&gt;This is the block title&lt;/langstring&gt;<br/>
-    &nbsp;&nbsp; &lt;langstring lang="es-MX"&gt;Esta es la descripción de los bloques&lt;/langstring&gt;<br/>
-    &lt;/description&gt;<br/>
+      ```html
+<description>
+    <langstring lang="en-US">This is the block title</langstring><br/>
+    <langstring lang="es-MX">Esta es la descripción de los bloques</langstring><br/>
+</description>
+    ```
     </td>
   </tr>
     <tr>
@@ -369,7 +371,7 @@ The data in this section is used for the block structures with group AU’s.  A 
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
   </tr>
@@ -382,6 +384,21 @@ The data in this section is used for the block structures with group AU’s.  A 
 The data in this section is used by Objectives. Objectives can be associated with a Block or with individual AU’s. 
 
 <table border="1" cellspacing="0" cellpadding="0">
+  <tr>
+    <td colspan="2" valign="top"><h3>id</h3></td>
+  </tr>
+  <tr>
+    <td width="183" valign="top"><p><strong>Required: </strong>Yes<br />
+        <strong>Data type:</strong> IRI</p>
+    </td>
+    <td width="792" valign="top"><p><strong>Description:</strong><br />
+      A unique IRI for the learning objective<br />
+      </p>
+      <p><strong>Value space:</strong><br/>Values defined by the course developer</p>
+    <p><strong>Sample value:</strong><br />
+    &lt;objective id="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
+    </td>
+  </tr>
   <tr>
     <td colspan="2" valign="top"><h3>title</h3></td>
   </tr>
@@ -400,21 +417,6 @@ The data in this section is used by Objectives. Objectives can be associated wit
     &nbsp;&nbsp; &lt;langstring lang="es-MX"&gt;Este es el título del objetivo&lt;/langstring&gt;<br/>
     &lt;/title&gt;<br/> 
       </p>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2" valign="top"><h3>id</h3></td>
-  </tr>
-  <tr>
-    <td width="183" valign="top"><p><strong>Required: </strong>Yes<br />
-        <strong>Data type:</strong> IRI</p>
-    </td>
-    <td width="792" valign="top"><p><strong>Description:</strong><br />
-      A unique IRI for the learning objective<br />
-      </p>
-      <p><strong>Value space:</strong><br/>Values defined by the course developer</p>
-    <p><strong>Sample value:</strong><br />
-    &lt;objective id="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
     </td>
   </tr>
   <tr>
@@ -458,66 +460,8 @@ AU’s may also contain objectives.
     <td width="1471" valign="top"><p><strong>Description: </strong>A globally unique IRI that the AU uses to identify itself to the LMS in xAPI messages to the LMS.</p>
       <p><strong>Value space: </strong>Values defined by course designer</p>
       <p><strong>Sample value:</strong><br/>
-      &lt;<au id="http://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
+      &lt;au id="<span>http</span>://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
       </p>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2" valign="top"><h3>title</h3></td>
-  </tr>
-  <tr>
-    <td valign="top"><p><strong>Required: </strong> Yes<br />
-        <strong>Data type:</strong> langstring</p></td>
-    <td valign="top"><p><strong>Description:</strong> A descriptive title for the AU<br />
-        </p>
-      <p><strong>Value space: </strong> Values defined by course designer<br />
-      </p>
-      <p><strong>Sample value: </strong><br/>
-
-    &lt;title&gt;<br/>
-    &nbsp;&nbsp;	&lt;langstring lang="en-US"&gt;This is an activity title.&lt;/langstring&gt;<br/>
-    &nbsp;&nbsp;	&lt;langstring lang="es-MX"&gt;Este es un título de la actividad.&lt;/langstring&gt;<br/>
-    &lt;/title&gt;<br/>
-
-      </p>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2" valign="top"><h3>url</h3></td>
-  </tr>
-  <tr>
-    <td width="160" valign="top"><p><strong>Required:</strong> Yes<br />
-        <strong>Data type: </strong> string</p>
-    </td>
-    <td width="1471" valign="top"><p><strong>Description:</strong><br />
-      A relative or fully qualified URL that references the launch point of the AU.<br/>&nbsp;<br/>
-      To accomodate "non-browser" applications, an application specific protocol may be used in the url:<br/>
-      &lt;application&gt;://&lt;URL to content&gt;
-      
-      Regardless of the value of &lt;application&gt;, the remaining portion of the URL must conform to HTTP/S conventions, such as named value pair parameters.<br/>&nbsp;<br/>If the url includes a query string, the values from that query string must be merged with the CMI-5 parameters at launch time (see section 8.1.1 of the CMI-5 Runtime Environment).
-      </p>
-      <p><strong>Value space:</strong>Determined by AU developer</p>
-      <p><strong>Sample value:</strong><br/>
-      &lt;url&gt;<br/>
-      http://wwww.mycourses.com/courseX.html<br/>
-      &lt;/url&gt;
-      </p>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="2" valign="top"><h3>launchParameters</h3></td>
-  </tr>
-  <tr>
-    <td width="160" valign="top"><p><strong>Required:</strong> Yes<br />
-        <strong>Data type: </strong>string </p>
-    </td>
-    <td width="1471" valign="top"><p><strong>Description:</strong><br />
-      Static launch parameters defined by the AU designer.  The LMS is required to store this data and provide to the AU if    requested by the AU during runtime.<br />
-      </p>
-      <p><strong>Value space:</strong><br />
-        Values defined by AU designer</p>
-      <p><br />
-        <strong>Sample value: </strong> TBD</p>
     </td>
   </tr>
   <tr>
@@ -536,7 +480,7 @@ AU’s may also contain objectives.
       <p><strong>Value space: </strong>"OwnWindow", "AnyWindow"<br />
         <br />
       <strong>Sample value: </strong> <br/>
-      &lt;<au id="&hellip;" launchMethod="OwnWindow"&gt; &hellip; &lt;/au&gt;
+      &lt;au id="&hellip;" launchMethod="OwnWindow"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -557,7 +501,7 @@ AU’s may also contain objectives.
       <p><strong>Value space: </strong>Decimal number or empty string<br />
         <br />
       <strong>Sample value: </strong><br/>
-      &lt;<au id="&hellip;" masteryScore="0.85"&gt; &hellip; &lt;/au&gt;
+      &lt;au id="&hellip;" masteryScore="0.85"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -589,7 +533,7 @@ AU’s may also contain objectives.
           "Not Applicable"</p>
       </blockquote>
       <p><strong>Sample value: </strong><br/>
-      &lt;<au id="&hellip;" moveOn="Passed"&gt; &hellip; &lt;/au&gt;
+      &lt;au id="&hellip;" moveOn="Passed"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -614,28 +558,32 @@ AU’s may also contain objectives.
       </p>
       </blockquote>
       <p><strong>Sample value: </strong><br/>
-      &lt;<au id="&hellip;" authenticationMethod="Basic"&gt; &hellip; &lt;/au&gt;
+      &lt;au id="&hellip;" authenticationMethod="Basic"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
+
   <tr>
-    <td colspan="2" valign="top"><h3>entitlementKey</h3></td>
+    <td colspan="2" valign="top"><h3>title</h3></td>
   </tr>
   <tr>
-    <td valign="top"><p><strong>Required:</strong> Yes<br />
-        <strong>Data type:</strong> string </p></td>
-    <td valign="top"><p><strong>Description:</strong><br />
-        Data used by the AU to determine if the launching LMS system is entitled to use the AU. The AU should use this data in combination with other data provided from the LMS to determine entitlement.<br />
-    </p>
-      <p><strong>Value space: </strong>Values defined by AU content provider.<br />
-        <br />
-        <strong>Sample value:</strong><br/>
-        &lt;entitlementKey&gt;<br/>
-        xyz-123-9999<br/>
-        &lt;/entitlementKey&gt;
+    <td valign="top"><p><strong>Required: </strong> Yes<br />
+        <strong>Data type:</strong> langstring</p></td>
+    <td valign="top"><p><strong>Description:</strong> A descriptive title for the AU<br />
         </p>
+      <p><strong>Value space: </strong> Values defined by course designer<br />
+      </p>
+      <p><strong>Sample value: </strong><br/>
+
+    &lt;title&gt;<br/>
+    &nbsp;&nbsp;	&lt;langstring lang="en-US"&gt;This is an activity title.&lt;/langstring&gt;<br/>
+    &nbsp;&nbsp;	&lt;langstring lang="es-MX"&gt;Este es un título de la actividad.&lt;/langstring&gt;<br/>
+    &lt;/title&gt;<br/>
+
+      </p>
     </td>
   </tr>
+
   <tr>
     <td colspan="2" valign="top"><h3>description</h3></td>
   </tr>
@@ -673,9 +621,65 @@ AU’s may also contain objectives.
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
+  </tr>  
+  <tr>
+    <td colspan="2" valign="top"><h3>url</h3></td>
+  </tr>
+  <tr>
+    <td width="160" valign="top"><p><strong>Required:</strong> Yes<br />
+        <strong>Data type: </strong> string</p>
+    </td>
+    <td width="1471" valign="top"><p><strong>Description:</strong><br />
+      A relative or fully qualified URL that references the launch point of the AU.<br/>&nbsp;<br/>
+      To accomodate "non-browser" applications, an application specific protocol may be used in the url:<br/>
+      &lt;application&gt;://&lt;URL to content&gt;
+      
+      Regardless of the value of &lt;application&gt;, the remaining portion of the URL must conform to HTTP/S conventions, such as named value pair parameters.<br/>&nbsp;<br/>If the url includes a query string, the values from that query string must be merged with the CMI-5 parameters at launch time (see section 8.1.1 of the CMI-5 Runtime Environment).
+      </p>
+      <p><strong>Value space:</strong>Determined by AU developer</p>
+      <p><strong>Sample value:</strong><br/>
+      &lt;url&gt;<br/>
+      <span>http</span>://wwww.mycourses.com/courseX.html<br/>
+      &lt;/url&gt;
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" valign="top"><h3>launchParameters</h3></td>
+  </tr>
+  <tr>
+    <td width="160" valign="top"><p><strong>Required:</strong> Yes<br />
+        <strong>Data type: </strong>string </p>
+    </td>
+    <td width="1471" valign="top"><p><strong>Description:</strong><br />
+      Static launch parameters defined by the AU designer.  The LMS is required to store this data and provide to the AU if    requested by the AU during runtime.<br />
+      </p>
+      <p><strong>Value space:</strong><br />
+        Values defined by AU designer</p>
+      <p><br />
+        <strong>Sample value: </strong> TBD</p>
+    </td>
+  </tr>  
+  <tr>
+    <td colspan="2" valign="top"><h3>entitlementKey</h3></td>
+  </tr>
+  <tr>
+    <td valign="top"><p><strong>Required:</strong> Yes<br />
+        <strong>Data type:</strong> string </p></td>
+    <td valign="top"><p><strong>Description:</strong><br />
+        Data used by the AU to determine if the launching LMS system is entitled to use the AU. The AU should use this data in combination with other data provided from the LMS to determine entitlement.<br />
+    </p>
+      <p><strong>Value space: </strong>Values defined by AU content provider.<br />
+        <br />
+        <strong>Sample value:</strong><br/>
+        &lt;entitlementKey&gt;<br/>
+        xyz-123-9999<br/>
+        &lt;/entitlementKey&gt;
+        </p>
+    </td>
   </tr>
 </table>
 

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -244,7 +244,7 @@ The LMS must implement a means to create and maintain course structures.<br/>
 <a name="course_level_meta_data"/>
 ### 7.1.1 Course Level Meta-data  
  
-The following meta data elements are at the course level and  describe the course instance as a whole
+The following meta data attribute and elements are at the course level and  describe the course instance as a whole
 
 <table border="1" cellspacing="0" cellpadding="0">
   <tr>
@@ -253,7 +253,7 @@ The following meta data elements are at the course level and  describe the cours
   <tr>
     <td width="168" valign="top"><p><strong>Required</strong>: 
       Yes<br />
-      <strong>Data</strong> type: 
+      <strong>Data type</strong>: 
       langstring</p>
     </td>
     <td width="811" valign="top"><p><strong>Description:</strong><br />
@@ -278,7 +278,7 @@ The following meta data elements are at the course level and  describe the cours
   </tr>
   <tr>
     <td width="168" valign="top"><p><strong>Required</strong>: Yes<br />
-        <strong>Data</strong> type: langstring</p>
+        <strong>Data type</strong>: langstring</p>
     </td>
     <td width="811" valign="top"><p><strong>Description:</strong><br />
       A detailed  description of the course.</p>
@@ -294,20 +294,18 @@ The following meta data elements are at the course level and  describe the cours
     </td>
   </tr>
   <tr>
-    <td colspan="2" valign="top"><h3>courseId</h3></td>
+    <td colspan="2" valign="top"><h3>id</h3></td>
   </tr>
   <tr>
     <td width="168" valign="top"><p><strong>Required</strong>: Yes<br />
-        <strong>Data</strong> type: String</p>
+        <strong>Data</strong> type: IRI</p>
     </td>
     <td width="811" valign="top"><p><strong>Description</strong>:<br />
       A globally unique IRI (Internationalized Resource Identifier per RFC 3987) for the course.  Used to explicitly identify the course instance.</p>
       <p><strong>Value space: </strong><br />
         Values defined by course designer<br />
         <strong>Sample value: </strong><br />
-         &lt;courseId&gt;<br/>
-        http://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2
-        &lt;/courseId&gt;<br/></p>
+         &lt;course id="http://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/course&gt;<br/></p>
     </td>
   </tr>
 </table>
@@ -317,7 +315,7 @@ The following meta data elements are at the course level and  describe the cours
 <a name="block_meta_data"/>
 ### 7.1.2 Block Meta Data
 
-The data in this section is used for the block structures with group AU’s.  A Block consists of one or more AU’s. Blocks  can also contain Objectives and other Blocks.
+The data in this section is used for the block structures with group AU’s.  A Block consists of one or more AU’s. Blocks can also contain references to objectives and other Blocks.
 
 <table border="1" cellspacing="0" cellpadding="0">
   <tr>
@@ -336,7 +334,6 @@ The data in this section is used for the block structures with group AU’s.  A 
     &nbsp;&nbsp;	&lt;langstring lang="en-US"&gt;This is the block title&lt;/langstring&gt;<br/>
     &nbsp;&nbsp;	&lt;langstring lang="es-MX"&gt;Este es el título del bloque&lt;/langstring&gt;<br/>
     &lt;/title&gt;<br/>            
-      Day 1 – Overview of Systems</p>
     </td>
   </tr>
   <tr>
@@ -355,9 +352,26 @@ The data in this section is used for the block structures with group AU’s.  A 
     &lt;description&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="en-US"&gt;This is the block title&lt;/langstring&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="es-MX"&gt;Esta es la descripción de los bloques&lt;/langstring&gt;<br/>
-    &lt;/description&gt;<br/> 
-      Day 1 – Overview of Systems.  In this part of the course you will get a complete overview.</p>
+    &lt;/description&gt;<br/>
     </td>
+  </tr>
+    <tr>
+    <td colspan="2" valign="top"><h3>objectives</h3></td>
+  </tr>
+  <tr>
+    <td width="164" valign="top"><p><strong>Required: 
+      </strong>No<br />
+      <strong>Data type:</strong> objectiveReference </p>
+    </td>
+    <td width="811" valign="top"><p><strong>Description:</strong><br />
+      A listing of objectives referenced by this block.<br />
+      <strong>Value space</strong>:<br />
+      Values defined by course designer<br />
+      <strong>Sample value: </strong><br />
+    &lt;objectives&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &lt;/objectives&gt;<br/> 
+    </td>  
   </tr>
 </table>
 
@@ -369,7 +383,7 @@ The data in this section is used by Objectives. Objectives can be associated wit
 
 <table border="1" cellspacing="0" cellpadding="0">
   <tr>
-    <td colspan="2" valign="top"><h3>objectiveTitle</h3></td>
+    <td colspan="2" valign="top"><h3>title</h3></td>
   </tr>
   <tr>
     <td width="183" valign="top"><p><strong>Required:</strong> Yes<br />
@@ -381,32 +395,30 @@ The data in this section is used by Objectives. Objectives can be associated wit
         Values defined by course designer<br />
       </p>
       <p><strong>Sample value: </strong><br/>
-    &lt;objectiveTitle&gt;<br/>
+    &lt;title&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="en-US"&gt;This is the objective title&lt;/langstring&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="es-MX"&gt;Este es el título del objetivo&lt;/langstring&gt;<br/>
-    &lt;/objectiveTitle&gt;<br/> 
-
+    &lt;/title&gt;<br/> 
       </p>
     </td>
   </tr>
   <tr>
-    <td colspan="2" valign="top"><h3>objectiveId</h3></td>
+    <td colspan="2" valign="top"><h3>id</h3></td>
   </tr>
   <tr>
     <td width="183" valign="top"><p><strong>Required: </strong>Yes<br />
-        <strong>Data type:</strong> string</p>
+        <strong>Data type:</strong> IRI</p>
     </td>
     <td width="792" valign="top"><p><strong>Description:</strong><br />
       A unique IRI for the learning objective<br />
       </p>
       <p><strong>Value space:</strong><br/>Values defined by the course developer</p>
     <p><strong>Sample value:</strong><br />
-    &lt;objectiveId&gt;<br>http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2<br/>
-    &lt;/objectiveId&gt;</p>
+    &lt;objective id="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
     </td>
   </tr>
   <tr>
-    <td colspan="2" valign="top"><h3>objectiveDescription</h3></td>
+    <td colspan="2" valign="top"><h3>description</h3></td>
   </tr>
   <tr>
     <td width="183" valign="top"><p><strong>Required:</strong> Yes<br />
@@ -419,10 +431,10 @@ The data in this section is used by Objectives. Objectives can be associated wit
         Values defined by course designer<br />
         </p>
       <p><strong>Sample value: </strong><br/>
-    &lt;objectiveDescription&gt;<br/>
+    &lt;description&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="en-US"&gt;This is the objective description&lt;/langstring&gt;<br/>
     &nbsp;&nbsp; &lt;langstring lang="es-MX"&gt;Esta es la descripción objetiva&lt;/langstring&gt;<br/>
-    &lt;/objectiveDescription&gt;<br/>      
+    &lt;/description&gt;<br/>      
       </p>
     </td>
   </tr>
@@ -438,17 +450,15 @@ AU’s may also contain objectives.
 
 <table border="1" cellspacing="0" cellpadding="0">
   <tr>
-    <td colspan="2" valign="top"><h3>activityId</h3></td>
+    <td colspan="2" valign="top"><h3>id</h3></td>
   </tr>
   <tr>
     <td width="160" valign="top"><p><strong>Required: </strong> Yes<br />
-        <strong>Data type: </strong> string</p></td>
+        <strong>Data type: </strong> IRI</p></td>
     <td width="1471" valign="top"><p><strong>Description: </strong>A globally unique IRI that the AU uses to identify itself to the LMS in xAPI messages to the LMS.</p>
       <p><strong>Value space: </strong>Values defined by course designer</p>
       <p><strong>Sample value:</strong><br/>
-      &lt;activityId&gt;<br/>
-      http://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2<br/>
-      &lt;/activityId&gt;
+      &lt;<au id="http://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -526,9 +536,7 @@ AU’s may also contain objectives.
       <p><strong>Value space: </strong>"OwnWindow", "AnyWindow"<br />
         <br />
       <strong>Sample value: </strong> <br/>
-      &lt;launchMethod&gt;<br/>
-        "OwnWindow"<br/>
-      &lt;/launchMethod&gt;
+      &lt;<au id="&hellip;" launchMethod="OwnWindow"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -549,16 +557,15 @@ AU’s may also contain objectives.
       <p><strong>Value space: </strong>Decimal number or empty string<br />
         <br />
       <strong>Sample value: </strong><br/>
-      &lt;masteryScore&gt;<br/>
-        0.85<br/>
-      &lt;/masteryScore&gt;</p>
+      &lt;<au id="&hellip;" masteryScore="0.85"&gt; &hellip; &lt;/au&gt;
+      </p>
     </td>
   </tr>
   <tr>
     <td colspan="2" valign="top"><h3>moveOn</h3></td>
   </tr>
   <tr>
-    <td valign="top"><p><strong>LMS Required:</strong> Yes<br />
+    <td valign="top"><p><strong>Required:</strong> Yes<br />
         <strong>Data type:</strong> string <br/>
         <strong>Default Value:</strong> "Not Applicable" </p></td>
     <td valign="top"><p><strong>Description:</strong> Used by the LMS to determine if a AU has been sufficiently completed for the purposes determining overall course completion or determining if prequisites were met for other activites.. </p>
@@ -582,9 +589,7 @@ AU’s may also contain objectives.
           "Not Applicable"</p>
       </blockquote>
       <p><strong>Sample value: </strong><br/>
-      &lt;moveOn&gt;<br/>
-        Passed<br/>
-      &lt;/moveOn&gt;
+      &lt;<au id="&hellip;" moveOn="Passed"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -609,9 +614,7 @@ AU’s may also contain objectives.
       </p>
       </blockquote>
       <p><strong>Sample value: </strong><br/>
-      &lt;authenticationMethod&gt;<br/>
-      Basic<br/>
-      &lt;/authenticationMethod&gt;
+      &lt;<au id="&hellip;" authenticationMethod="Basic"&gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -654,6 +657,25 @@ AU’s may also contain objectives.
     &lt;/description&gt;<br/>   
       </p>
     </td>
+  </tr>
+    </tr>
+    <tr>
+    <td colspan="2" valign="top"><h3>objectives</h3></td>
+  </tr>
+  <tr>
+    <td width="164" valign="top"><p><strong>Required: 
+      </strong>No<br />
+      <strong>Data type:</strong> objectiveReference </p>
+    </td>
+    <td width="811" valign="top"><p><strong>Description:</strong><br />
+      A listing of objectives referenced by this AU.<br />
+      <strong>Value space</strong>:<br />
+      Values defined by course designer<br />
+      <strong>Sample value: </strong><br />
+    &lt;objectives&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &lt;/objectives&gt;<br/> 
+    </td>  
   </tr>
 </table>
 

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -259,7 +259,7 @@ The following meta data attribute and elements are at the course level and  desc
       <p><strong>Value space: </strong><br />
         Values defined by course designer<br />
         <strong>Sample value: </strong><br />
-         &lt;course id="<span>http</span>://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/course&gt;<br/></p>
+         &lt;course id="http://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/course&gt;<br/></p>
     </td>
   </tr>
   <tr>
@@ -349,12 +349,10 @@ The data in this section is used for the block structures with group AU’s.  A 
       <strong>Value space</strong>:<br />
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
-      ```html
-<description>
-    <langstring lang="en-US">This is the block title</langstring><br/>
-    <langstring lang="es-MX">Esta es la descripción de los bloques</langstring><br/>
-</description>
-    ```
+&lt;description&gt;
+    &lt;langstring lang="en-US"&gt;This is the block title&lt;/langstring&gt;<br/>
+    &gt;langstring lang="es-MX"&lt;Esta es la descripción de los bloques&lt;/langstring&gt;br/>
+&lt;/description&gt;
     </td>
   </tr>
     <tr>
@@ -371,7 +369,7 @@ The data in this section is used for the block structures with group AU’s.  A 
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
   </tr>
@@ -396,7 +394,7 @@ The data in this section is used by Objectives. Objectives can be associated wit
       </p>
       <p><strong>Value space:</strong><br/>Values defined by the course developer</p>
     <p><strong>Sample value:</strong><br />
-    &lt;objective id="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
+    &lt;objective id="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
     </td>
   </tr>
   <tr>
@@ -460,7 +458,7 @@ AU’s may also contain objectives.
     <td width="1471" valign="top"><p><strong>Description: </strong>A globally unique IRI that the AU uses to identify itself to the LMS in xAPI messages to the LMS.</p>
       <p><strong>Value space: </strong>Values defined by course designer</p>
       <p><strong>Sample value:</strong><br/>
-      &lt;au id="<span>http</span>://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
+      &lt;au id="http://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -621,7 +619,7 @@ AU’s may also contain objectives.
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="<span>http</span>://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
   </tr>  
@@ -642,7 +640,7 @@ AU’s may also contain objectives.
       <p><strong>Value space:</strong>Determined by AU developer</p>
       <p><strong>Sample value:</strong><br/>
       &lt;url&gt;<br/>
-      <span>http</span>://wwww.mycourses.com/courseX.html<br/>
+      http://wwww.mycourses.com/courseX.html<br/>
       &lt;/url&gt;
       </p>
     </td>

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -87,6 +87,7 @@ All previous work from 2012 discared
 | Michael Roberts      | VTraining Room                         |
 | Thomas Person        | (Formerly of Adobe)                    |
 | Art Werkenthin       | RISC,Inc                               |
+| Severin Neumann      | die eLearning AG                       |
 
 -------
 
@@ -663,96 +664,130 @@ The following is the XML Schema for a course structure file.
 All course structures created for LMS import and created by the LMS for export must conform to this XSD and be named cmi5.xml.
 
 ```XML
-<xs:schema xmlns="http://aicc.org/CMI5/CourseStructure.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-targetNamespace="http://aicc.org/CMI5/CourseStructure.xsd" elementFormDefault="qualified" id="CMI5CourseStructure">
-	<xs:element name="CourseStructure" type="CourseType"/>
-	<xs:complexType name="CourseType">
-		<xs:sequence minOccurs="1" maxOccurs="1">
-			<xs:element name="Course" minOccurs="1" maxOccurs="1">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="title" minOccurs="1" maxOccurs="1"/>
-						<xs:element name="description" minOccurs="1" maxOccurs="1"/>
-						<xs:element name="courseId" minOccurs="1" maxOccurs="1"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Block" type="BlockType" minOccurs="1" maxOccurs="1"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="BlockType">
-		<xs:sequence maxOccurs="unbounded">
-			<xs:element name="title" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="description" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="objectives" type="ObjectivesType" minOccurs="0" maxOccurs="1">
-				<!-- <xs:complexType>
-					<xs:sequence>
-						<xs:element name="Objective" minOccurs="1" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="ObjectiveID" minOccurs="1" maxOccurs="1"/>
-									<xs:element name="ObjectiveTitle" minOccurs="1" maxOccurs="1"/>
-									<xs:element name="ObjectiveDescription" minOccurs="1" maxOccurs="1"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType> -->
-			</xs:element>
-			<xs:element name="AU" type="AUtype" minOccurs="0"/>
-			<xs:element name="Block" minOccurs="0">
-				<xs:complexType>
-					<xs:complexContent>
-						<xs:extension base="BlockType"/>
-					</xs:complexContent>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="AUtype">
-		<xs:sequence>
-			<xs:element name="activityId" minOccurs="1" maxOccurs="1"/>			
-			<xs:element name="title" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="url" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="launchParameters" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="launchMethod" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="masteryScore" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="moveOn" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="authenticationMethod" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="entitlementKey" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="description" minOccurs="1" maxOccurs="1"/>
-			<xs:element name="objectives" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="objective" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="objectiveID"/>
-									<xs:element name="objectiveTitle"/>
-									<xs:element name="objectiveDescription"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="ObjectivesType">
-		<xs:sequence>
-			<xs:element name="objective" minOccurs="1" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="objectiveID" minOccurs="1" maxOccurs="1"/>
-						<xs:element name="objectiveTitle" minOccurs="1" maxOccurs="1"/>
-						<xs:element name="objectiveDescription" minOccurs="1" maxOccurs="1"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-</xs:schema>
+<xs:schema xmlns="http://aicc.org/CMI5/CourseStructure.xsd"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://aicc.org/CMI5/CourseStructure.xsd" elementFormDefault="qualified"
+           id="CMI5CourseStructure">
+    <xs:element name="courseStructure" type="courseType"/>
+    <xs:complexType name="courseType">
+        <xs:all>
+            <xs:element name="course">
+                <xs:complexType>
+                    <xs:all>
+                        <xs:element name="title" type="textType"/>
+                        <xs:element name="description" type="textType"/>
+                    </xs:all>
+                    <xs:attribute name="id" type="xs:anyURI" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="block" type="blockType"/>
+            <xs:element name="objectives" type="objectivesType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="blockType">
+        <xs:sequence>
+            <xs:element name="title" type="textType"/>
+            <xs:element name="description" type="textType"/>
+            <xs:element name="objectives" type="referencesObjectivesType" minOccurs="0"/>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="au" type="auType"/>
+                <xs:element name="block" type="blockType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="auType">
+        <xs:all>
+            <xs:element name="title" type="textType"/>
+            <xs:element name="description" type="textType"/>
+            <xs:element name="objectives" type="referencesObjectivesType" minOccurs="0"/>
+            <xs:element name="url">
+                <xs:simpleType>
+                    <xs:restriction base="xs:anyURI">
+                        <xs:minLength value="1"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="launchParameters"/>
+            <xs:element name="entitlementKey"/>
+        </xs:all>
+        <xs:attribute name="id" type="xs:anyURI" use="required"/>
+        <xs:attribute name="moveOn" default="Not Applicable">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Not Applicable"/>
+                    <xs:enumeration value="Passed"/>
+                    <xs:enumeration value="Completed"/>
+                    <xs:enumeration value="Completed And Passed"/>
+                    <xs:enumeration value="Completed Or Passed"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="masteryScore" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:decimal">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="authenticationMethod" default="Basic">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Basic"/>
+                    <xs:enumeration value="OAuth"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="launchMethod" default="AnyWindow">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="AnyWindow"/>
+                    <xs:enumeration value="OwnWindow"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="objectivesType">
+        <xs:sequence>
+            <xs:element name="objective" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:all>
+                        <xs:element name="title" type="textType"/>
+                        <xs:element name="description" type="textType"/>
+                    </xs:all>
+                    <xs:attribute name="id" type="xs:anyURI" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
 
+    <xs:complexType name="referencesObjectivesType">
+        <xs:sequence>
+            <xs:element name="objective" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="idref" type="xs:anyURI"></xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="textType">
+        <xs:complexContent>
+            <xs:extension base="xs:string">
+                <xs:sequence>
+                    <xs:element name="langstring" maxOccurs="unbounded" minOccurs="0">
+                        <xs:complexType>
+                            <xs:complexContent>
+                                <xs:extension base="xs:string">
+                                    <xs:attribute name="lang" type="xs:language"/>
+                                </xs:extension>
+                            </xs:complexContent>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>
 ```
 
 <a name="course_package"/>

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -660,11 +660,11 @@ AU’s may also contain objectives.
 ## 7.2 Course Structure XSD 
 
 The following is the XML Schema for a course structure file.  
-All course structures created for LMS import and creaated by the LMS for export must conform to this XSD and be named cmi5.xml.
+All course structures created for LMS import and created by the LMS for export must conform to this XSD and be named cmi5.xml.
 
 ```XML
 <xs:schema xmlns="http://aicc.org/CMI5/CourseStructure.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-target-Namespace="http://aicc.org/CMI5/CourseStructure.xsd" elementFormDefault="qualified" id="CMI5CourseStructure">
+targetNamespace="http://aicc.org/CMI5/CourseStructure.xsd" elementFormDefault="qualified" id="CMI5CourseStructure">
 	<xs:element name="CourseStructure" type="CourseType"/>
 	<xs:complexType name="CourseType">
 		<xs:sequence minOccurs="1" maxOccurs="1">
@@ -738,7 +738,7 @@ target-Namespace="http://aicc.org/CMI5/CourseStructure.xsd" elementFormDefault="
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="objectivesType">
+	<xs:complexType name="ObjectivesType">
 		<xs:sequence>
 			<xs:element name="objective" minOccurs="1" maxOccurs="unbounded">
 				<xs:complexType>

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -259,7 +259,7 @@ The following meta data attribute and elements are at the course level and  desc
       <p><strong>Value space: </strong><br />
         Values defined by course designer<br />
         <strong>Sample value: </strong><br />
-         &lt;course id="http://www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/course&gt;<br/></p>
+         &lt;course id="http&#58;//www.yoursite.com/identifiers/course/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/course&gt;<br/></p>
     </td>
   </tr>
   <tr>
@@ -349,10 +349,10 @@ The data in this section is used for the block structures with group AU’s.  A 
       <strong>Value space</strong>:<br />
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
-&lt;description&gt;
-    &lt;langstring lang="en-US"&gt;This is the block title&lt;/langstring&gt;<br/>
-    &gt;langstring lang="es-MX"&lt;Esta es la descripción de los bloques&lt;/langstring&gt;br/>
-&lt;/description&gt;
+&lt;description&gt;<br />
+&nbsp;&nbsp;    &lt;langstring lang="en-US"&lt;This is the block description&lt;/langstring&gt;<br/>
+&nbsp;&nbsp;    &lt;langstring lang="es-MX"&lt;Esta es la descripción de los bloques&lt;/langstring&gt;<br/>
+&lt;/description&gt;<br />
     </td>
   </tr>
     <tr>
@@ -369,7 +369,7 @@ The data in this section is used for the block structures with group AU’s.  A 
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http&#58;//www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2" /&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
   </tr>
@@ -394,7 +394,7 @@ The data in this section is used by Objectives. Objectives can be associated wit
       </p>
       <p><strong>Value space:</strong><br/>Values defined by the course developer</p>
     <p><strong>Sample value:</strong><br />
-    &lt;objective id="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"&gt;&hellip;&lt;/objectiveId&gt;</p>
+    &lt;objective id="http&#58;//www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt;&hellip;&lt;/objective&gt;</p>
     </td>
   </tr>
   <tr>
@@ -458,7 +458,7 @@ AU’s may also contain objectives.
     <td width="1471" valign="top"><p><strong>Description: </strong>A globally unique IRI that the AU uses to identify itself to the LMS in xAPI messages to the LMS.</p>
       <p><strong>Value space: </strong>Values defined by course designer</p>
       <p><strong>Sample value:</strong><br/>
-      &lt;au id="http://www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2"&lt; &hellip; &lt;/au&gt;
+      &lt;au id="http&#58;//www.yoursite.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt; &hellip; &lt;/au&gt;
       </p>
     </td>
   </tr>
@@ -619,7 +619,7 @@ AU’s may also contain objectives.
       Values defined by course designer<br />
       <strong>Sample value: </strong><br />
     &lt;objectives&gt;<br/>
-    &nbsp;&nbsp; &lt;objective idref="http://www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2"/&gt;<br/>
+    &nbsp;&nbsp; &lt;objective idref="http&#58;//www.yoursite.com/identifiers/objective/005430bf-b3ba-45e6-b47b-d629603d83d2" /&gt;<br/>
     &lt;/objectives&gt;<br/> 
     </td>  
   </tr>  


### PR DESCRIPTION
Hi,

this pull request contains all changes discussed during the last two meetings:

- Elements like id, moveOn, etc. are converted to attributes
- Objectives are centralized and referenced by au or block
- The XSD is reflecting these changes and also contains some other fixes like ```<langstring>```

Regards,
Severin