### PR TITLE
Using langstring is an requirement

### DIFF
--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -843,11 +843,11 @@ All course structures created for LMS import and created by the LMS for export M
     <xs:sequence>
       <xs:element name="langstring" maxOccurs="unbounded" minOccurs="1">
         <xs:complexType>
-          <xs:complexContent>
+          <xs:simpleContent>
             <xs:extension base="xs:string">
               <xs:attribute name="lang" type="xs:language"/>
             </xs:extension>
-          </xs:complexContent>
+          </xs:simpleContent>
         </xs:complexType>
       </xs:element>
     </xs:sequence>

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -840,21 +840,17 @@ All course structures created for LMS import and created by the LMS for export M
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="textType">
-    <xs:complexContent>
-      <xs:extension base="xs:string">
-        <xs:sequence>
-          <xs:element name="langstring" maxOccurs="unbounded" minOccurs="0">
-            <xs:complexType>
-              <xs:complexContent>
-                <xs:extension base="xs:string">
-                  <xs:attribute name="lang" type="xs:language"/>
-                </xs:extension>
-              </xs:complexContent>
-            </xs:complexType>
-          </xs:element>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
+    <xs:sequence>
+      <xs:element name="langstring" maxOccurs="unbounded" minOccurs="1">
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="lang" type="xs:language"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 </xs:schema>
 ```


### PR DESCRIPTION
The given patch makes the use of langstring an requirement. For me this seems to be the correct interpretation of the specification. So this makes the following illegal:

```xml
<course id="...">
  <title>This is a title</title>
  <description>Wer hätte gedacht, dass die Beschreibung auf Deutsch ist?!</description>
</course>
```

The modification only allows the following:

```xml
<course id="...">
  <title>
    <langstring lang="en-US">This is a title</langstring>
  </title>
  <description>
    <langstring lang="de-DE">Wer hätte gedacht, dass die Beschreibung auf Deutsch ist?!</langstring>
  </description>
</course>
```

The disadvantage of this change might be, that people will nevertheless skip the ```<langstring>``` because they are used to it...

**Remark**: The given example shows that it is possible to have different languages for title and description. As far as I know it is not possible to enforce that there is a title and a description for each language by just using XSD.

