### PR TITLE
Added languages element to course structure

### DIFF
--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -309,6 +309,25 @@ The following meta data attribute and elements are at the course level and  desc
         </p>
     </td>
   </tr>
+  <tr>
+    <td colspan="2" valign="top"><h3>languages</h3></td>
+  </tr>
+  <tr>
+    <td width="168" valign="top"><p><strong>Required</strong>: No<br />
+        <strong>Data type</strong>: RFC 5646 language tags</p>
+    </td>
+    <td width="811" valign="top"><p><strong>Description:</strong><br />
+      Specifies which languages will be supported by the course. All of the languages list MUST be present in a langstring for each title or description element. The LMS will be expected to display the language specific titles and descriptions for course elements based on the learner’s language preference.</p>
+      <p><strong>Value space:</strong><br />
+         Values defined by course designer</p>
+      <p><strong>Sample value: </strong><br />
+    &lt;languages&gt;<br/>
+    &nbsp;&nbsp;en-US<br/>
+    &nbsp;&nbsp;es-MX<br/>
+    &lt;/languages&gt;<br/>
+        </p>
+    </td>
+  </tr>
 </table>
 
 
@@ -743,6 +762,7 @@ All course structures created for LMS import and created by the LMS for export M
           <xs:all>
             <xs:element name="title" type="textType"/>
             <xs:element name="description" type="textType"/>
+            <xs:element name="languages" minOccurs="0" type="languagesType"></xs:element>
           </xs:all>
           <xs:attribute name="id" type="xs:anyURI" use="required"/>
         </xs:complexType>
@@ -856,6 +876,9 @@ All course structures created for LMS import and created by the LMS for export M
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="languagesType">
+    <xs:list itemType="xs:language"></xs:list>
+  </xs:simpleType>
 </xs:schema>
 ```
 


### PR DESCRIPTION
As discussed in the [April 10th meeting](https://github.com/AICC/CMI-5_Spec_Current/wiki/CMI-5-Working-Group-Meeting-Minutes-%E2%80%93-April-10th,-2015) I have added the element ```<languages>``` to the course structure. This allows to write the following:

```xml
<course id="course">
  <title>...</title>
  <description>...</description>
  <languages>en-US es-MX</languages>
</course>
```
I slightly modified the notation: I renamed the element from "language" to "languages" and I fixed the listing from named elements (```<en-US>```, ```<es-MX>```) to space separated strings. 