### PR TITLE
Example value for launchParameters

### DIFF
--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -710,7 +710,18 @@ AUs may also contain objectives.
       <p><strong>Value space:</strong><br />
         Values are defined by the course designer.</p>
       <p><br />
-        <strong>Sample value: </strong> TBD</p>
+        <strong>Sample value:</strong><br/>
+        &lt;launchParameters&gt;<br/>
+        &nbsp;&nbsp;{<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;"param1": "Lorem ipsum dolor sit amet",<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;"param2": [1,2,3,4,5],<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;"param3": {<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"a": 1,<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"b": 2<br />
+        &nbsp;&nbsp;}<br />
+        &nbsp;&nbsp;}<br />
+        &lt;/launchParameters&gt;
+        </p>
     </td>
   </tr>  
   <tr>

--- a/cmi5_coursestructure.md
+++ b/cmi5_coursestructure.md
@@ -712,15 +712,7 @@ AUs may also contain objectives.
       <p><br />
         <strong>Sample value:</strong><br/>
         &lt;launchParameters&gt;<br/>
-        &nbsp;&nbsp;{<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;"param1": "Lorem ipsum dolor sit amet",<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;"param2": [1,2,3,4,5],<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;"param3": {<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"a": 1,<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"b": 2<br />
-        &nbsp;&nbsp;}<br />
-        &nbsp;&nbsp;}<br />
-        &lt;/launchParameters&gt;
+        {"param1": "Lorem ipsum dolor sit amet", "param2": [1,2,3,4,5],"param3": {"a": 1,"b": 2}}<br />
         </p>
     </td>
   </tr>  


### PR DESCRIPTION
The following pull request is an suggestion as well as a question, if I'm understanding the meaning of this element correctly:

Suggestion: The course structure specification had a "TBD" for the ```<launchParameters>``` example value, so I added a possible xample.

Question: The added example is a json string. My understanding of a discussion during one of our meetings was, that the launch parameters can be used to provide some generic kind of configuration. By "generic" I mean that the course designer can choose any format he likes, e.g. some proprietary text format (KK3;XD;T_0) or some existing format (json, xml(?!), yaml, ...). Is this assumption correct?