### PR TITLE
Remove remaining oAuth references (Per Issue #235.)

### DIFF
--- a/cmi5_runtime.md
+++ b/cmi5_runtime.md
@@ -295,7 +295,7 @@ Course structures MUST contain the following data for each AU in a course:
 * Launch Method - 
     * "OwnWindow" – The LMS MUST either spawn a new window for the AU launched, or redirect the existing window to the AU.
     * "AnyWindow" – The AU does not care about the window context (all browser windows options are acceptable – FrameSet, New Window, redirect, etc.) The LMS may use whichever method is desired.
-* Authentication Method – The authentication method used by the AU to access the LMS's LRS.  (Either HTTP Basic or OAuth 1.0)
+* Authentication Method – The authentication method used by the AU to access the LMS's LRS.
 * Launch Parameters – A set of static data specific to the AU’s design. Used as parameters by the AU to modify its behavior. 
 * Entitlement Key – This is a value provided by the AU content provider and is used by the AU to determine whether the LMS instance and/or learner are entitled to view the content. It is provided to the AU via a State API request.
 
@@ -402,7 +402,7 @@ The format of the launching URL is as follows:
 ```
 <URL to AU>
 ?endpoint=<URL to LMS Listener>
-&fetch=<Fetch URL for Authorization Token (optional)– if OAuth is not used>
+&fetch=<Fetch URL for the Authorization Token>
 &actor=<Actor>
 &registration=<Registration ID>
 &activityId=<AU activity ID>
@@ -434,9 +434,9 @@ The values for the URL launch parameters are described below:
 
 <table>
   <tr><th colspan=3 align ="left">fetch</th></tr>
-  <tr><td>&nbsp;</td><th align ="right">Description:</th><td>The <strong><em>fetch</em></strong> URL is used by the AU to obtain an authentication token created &amp; managed by the LMS.  The <strong><em>fetch</em></strong> URL is only used when OAuth authentication is not practical or desired.  The authentication token is used by the AU being launched.</td></tr>
-  <tr><td>&nbsp;</td><th align ="right">LMS Usage:</th><td>The LMS MUST place the <strong><em>fetch</em></strong> in the Launch URL when Basic authentication is indicated in the course structure definition. <br /><br />If OAuth is the method of authentication specified, the LMS MUST NOT place the <strong><em>fetch</em></strong>name/value pair<strong></strong> in the query string.  <br /><br />The <strong><em>fetch</em></strong> URL is a "one-time use" URL and subsequent uses SHOULD generate an error as defined in section 8.2. The authorization token returned by the <strong><em>fetch</em></strong> URL MUST be limited to the duration of a specific user session. </td></tr>
-  <tr><td>&nbsp;</td><th align ="right" >AU Usage:</th><td>When Basic authentication is used, the AU MUST get the <strong><em>fetch</em></strong> value from the query string. The AU MUST make an HTTP POST to the <strong><em>fetch</em></strong> URL to retrieve the authorization token as defined in section 8.2. The AU MUST then place the authorization token in the Authorization headers of all HTTP messages made to the endpoint using the xAPI.  The AU SHOULD NOT make more than one post to the <strong><em>fetch</em></strong> URL</td></tr>
+  <tr><td>&nbsp;</td><th align ="right">Description:</th><td>The <strong><em>fetch</em></strong> URL is used by the AU to obtain an authentication token created &amp; managed by the LMS. The authentication token is used by the AU being launched.</td></tr>
+  <tr><td>&nbsp;</td><th align ="right">LMS Usage:</th><td>The LMS MUST place the <strong><em>fetch</em></strong> in the Launch URL. <br />The <strong><em>fetch</em></strong> URL is a "one-time use" URL and subsequent uses SHOULD generate an error as defined in section 8.2. The authorization token returned by the <strong><em>fetch</em></strong> URL MUST be limited to the duration of a specific user session. </td></tr>
+  <tr><td>&nbsp;</td><th align ="right" >AU Usage:</th><td>The AU MUST get the <strong><em>fetch</em></strong> value from the query string. The AU MUST make an HTTP POST to the <strong><em>fetch</em></strong> URL to retrieve the authorization token as defined in section 8.2. The AU MUST then place the authorization token in the Authorization headers of all HTTP messages made to the endpoint using the xAPI.  The AU SHOULD NOT make more than one post to the <strong><em>fetch</em></strong> URL</td></tr>
   <tr><td>&nbsp;</td><th align ="right">Data type:</th><td>String (URL-encoded)</td></tr>
   <tr><td>&nbsp;</td><th align ="right" nowrap>Value space:</th><td>Defined by the LMS</td></tr>
   <tr><td>&nbsp;</td><th align ="right" nowrap>Sample value:</th><td>http://cmi5-lms-system.org/tokenGen.htm?k=2390289x0</td></tr>
@@ -476,7 +476,7 @@ The values for the URL launch parameters are described below:
 <a name="fetch_url"></a>  
 ##8.2 Authorization Token Fetch URL
 ###8.2.1 Overview
-When Basic authentication is used, the LMS MUST include the <strong><em>fetch</em></strong> name/value pair in the launch URL.  The AU MUST make an HTTP POST to the <strong><em>fetch</em></strong> URL to retrieve an authorization token.  Please note than an HTTP GET is not allowed in order to prevent caching of the request.
+The LMS MUST include the <strong><em>fetch</em></strong> name/value pair in the launch URL.  The AU MUST make an HTTP POST to the <strong><em>fetch</em></strong> URL to retrieve an authorization token.  Please note than an HTTP GET is not allowed in order to prevent caching of the request.
 
 The <strong><em>fetch</em></strong> URL MUST return a JSON structure using a content-type of "application/json". An example JSON structure is shown below:
 ```javascript
@@ -492,7 +492,7 @@ The AU SHOULD NOT attempt to retrieve the authorization token more than once.  T
 ###8.2.2 Definition: auth-token
 <table>
   <tr><th colspan=3 align ="left">auth-token</th></tr>
-  <tr><td>&nbsp;</td><th align ="right" nowrap>Description:</th><td>An authorization token used in all xAPI communications with the LMS when Basic authentication is used.</td></tr>
+  <tr><td>&nbsp;</td><th align ="right" nowrap>Description:</th><td>An authorization token used in all xAPI communications with the LMS.</td></tr>
   <tr><td>&nbsp;</td><th align ="right" nowrap>LMS Usage:</th><td>The LMS MUST place the value for <strong><em>auth-token</em></strong> in a JSON structure, as shown in Section 8.2.1, in its response to a <strong><em>fetch</em></strong> URL request. The response MUST have a content-type of "application/json".</td></tr>
   <tr><td>&nbsp;</td><th align ="right" >AU Usage:</th><td>The AU MUST get the <strong><em>auth-token</em></strong> value using an HTTP POST to the <strong><em>fetch</em></strong> URL. The AU MUST then place the authorization token in the Authorization headers of all HTTP messages made to the endpoint using the xAPI.</td></tr>
   <tr><td>&nbsp;</td><th align ="right" nowrap>Data type:</th><td>String (URL-encoded)</td></tr>


### PR DESCRIPTION
Remove remaining references to oAuth (and statements that indicate that there is an alternative form of authentication) in the cmi5 runtime specification.  

Per Issue #235.