### PR TITLE
Quartz

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ All are welcome to make raise issues/comments on this GitHub repository.
 
 Also, [please see our wiki](https://github.com/AICC/CMI-5_Spec_Current/wiki) for a comprehensive set of meeting minutes.
 
+### cmi5 Email Address
+Please send questions for the working group to: [cmi5wg@adlnet.gov](mailto://cmi5wg@adlnet.gov)
+
 ### Weekly GotoMeeting Conferences
 
 The cmi5 working group holds weekly Web Conferences that are open to all. The meeting are held every Friday at 10:30 am US Eastern Time. See link below to register:
@@ -146,5 +149,8 @@ The cmi5 LinkedIn group was established to encourage discussion about cmi5 and a
 
 Follow cmi5 on Twitter: [#cmi5](https://twitter.com/hashtag/cmi5), [@cmi5spec](https://twitter.com/cmi5spec)
 
+### Join the cmi5 Slack Team
+
+The cmi5 working group is currently testing Slack team communication. To join the slack group, please use the following link: [Add me to the cmi5 Slack Team](mailto://cmi5wg@adlnet.gov?subject=%5Bcmi5+Slack+Registration%5D&body=Please+add+me+to+the+cmi5+slack+working+group.)
 
 ----------

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -128,6 +128,7 @@ __0.1 Convert Working Draft to Markdown in GitHub (Feb 20, 2013):__
 | Thomas Person        | (Formerly of Adobe)                    |
 | Art Werkenthin       | RISC,Inc                               |
 | Severin Neumann      | die eLearning AG                       |
+| Chris Amyot	       | ICOM Productions, Inc.                 |
 | David Pesce          | Exputo Inc.                            |
 | Henry Ryng           | inXsol					|
 | Chris Handorf        | Pearson                                |


### PR DESCRIPTION
Bill - as per Oct. 2 meeting, I've added the cmi5 email address and slack information to the README.md I've also added myself to the list of contributors (shameless self promotion never hurts, right?)

The slack link just uses a mailto to the working group email with some standard jargon in the subject and body:

Subject: [cmi5 Slack Registration]
Body: Please add me to the cmi5 slack working group.

Does this hit the mark?