### PR TITLE
Fixed Slack Request Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ Follow cmi5 on Twitter: [#cmi5](https://twitter.com/hashtag/cmi5), [@cmi5spec](h
 
 ### Join the cmi5 Slack Team
 
-The cmi5 working group is currently testing Slack team communication. To join the slack group, please use the following link: [Add me to the cmi5 Slack Team](mailto://cmi5wg@adlnet.gov?subject=%5Bcmi5+Slack+Registration%5D&body=Please+add+me+to+the+cmi5+slack+working+group.)
+The cmi5 working group is currently testing Slack team communication. To join the slack group, please use the following link: [Add me to the cmi5 Slack Team](mailto:cmi5wg@adlnet.gov?subject=%5Bcmi5%20Slack%20Registration%5D&body=Please%20add%20me%20to%20the%20cmi5%20slack%20working%20group.)
 
 ----------


### PR DESCRIPTION
A "mailto:" does not require the slashes. And I assume that the "+" should be spaces (%20)