### PR TITLE
Add rejection/voiding rules for LMS

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -317,6 +317,8 @@ The LMS MUST meet the following requirements to conform to this specification:
 * The LMS MUST implement a means to import course structures as defined in Section 6.1.
 * The LMS MUST NOT provide permissions/credentials which allow the AU to issue voiding Statements.
 * The LMS SHOULD implement a means to export course structures as defined in Section 6.1.
+* The LMS SHOULD reject statements that conflict with the "Statement API" requirements as defined in Section 9.
+* The LMS MUST void statements that are NOT rejected AND conflict with the "Statement API" requirements as defined in Section 9.
 
 <a name="course_structures"></a>  
 ##6.1 Course Structures


### PR DESCRIPTION
Per CMI 5 Working Group Meeting Minutes – September 18th, 2015 (issue #262 and #263)

As part of the discussion on issues 262/263, the issue of how the LMS should deal with statements that conflict with cmi5 spec rules came up.

The group agreed that the following rules should be added to cmi5 spec to clarify what the LMS should/must do:

1. LMS SHOULD reject statements that conflict with the spec.
2. Any statement that conflicts with the cmi5 specification rules that is NOT rejected MUST be voided by the LMS.