### PR TITLE
Items related to Result objects

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -786,7 +786,7 @@ An Example of usage in a statement:
 
 <a name="result"></a> 
 ##9.5 Result
-Result may be present in a statement depending on the cmi5 verb used.  
+Result may be present in a statement depending on the cmi5 verb used. A "cmi5 defined" statement MUST NOT use result properties not specified for that particular verb except in the case of result extensions.
 
 Example JSON:
 ```javascript
@@ -798,7 +798,6 @@ Example JSON:
     "max": 100
   },
   "success": false,
-  "completion": false,
   "duration": "PT30M",
   "extensions": {
     "http://purl.org/xapi/cmi5/result/extensions/progress": 100
@@ -828,7 +827,6 @@ The success property of the result MUST be set to true for statements having the
 The success property of the result MUST be set to false for statements having the following cmi5 defined verbs:
 
 - Failed
-- Abandoned
 
 <a name="completion"></a>
 ###9.5.3 Completion
@@ -839,7 +837,6 @@ The completion property of the result MUST be set to true for statements having 
 
 The completion property of the result MUST be set to false for statements having the following cmi5 defined verbs:
 
-- Failed
 - Abandoned
 
 <a name="duration"></a>


### PR DESCRIPTION
* Correct which verbs can include "success" (remove Abandoned)
* Correct which verbs can include "completion" (remove Failed)
* Make JSON example conformant for possible inclusion

Addresses #330 and #331.

The example JSON wasn't conformant because there is no way to record a single statement with both `success: false` and `completion: false`. (Also it'd likely be bad form to have a progress of 100% but not completed, though I suppose it is possible (unless that's an issue onto itself?))