### PR TITLE
For-Issue #378-section-6.1-only

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -348,7 +348,7 @@ LMS requirements to conform to this specification are as follows:
 <a name="course_structures"></a>  
 ##6.1 Course Structures
 
-* The LMS SHOULD implement a means to create and maintain course structures.<br>
+* The LMS SHOULD implement a means to create, edit, and maintain course structures.<br>
 * The LMS MUST implement the import of the Course Structure defined in Section 13 and Section 14. <br>
 * The LMS SHOULD implement the export of the course data structure defined in Section 13 and Section 14. <br>
 * The LMS SHOULD provide a user interface to the LMS administrative users to create and edit course structures internally.<br>


### PR DESCRIPTION
Issue #378 - Explicitly allow the LMS to override the "masteryScore" as defined in the course structure

(Section 6.1 only)  Per January 29th, 2016 Meeting  (The rest of issue #378 is not resolved yet)