### PR TITLE
object.id no longer directly related to course structure

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -759,7 +759,7 @@ The objectType property of an Object in statements with a cmi5 verb MUST be set 
 
 <a name="object_id"></a> 
 ###9.4.2 id 
-The value of the Object's ID property for a given AU MUST match the AU ID (activityId) defined in the launch URL and the Course Structure.
+The value of the Object's "id" property for a given AU MUST match the AU ID (activityId) defined in the launch URL.
 
 An Example of usage in a statement:
 


### PR DESCRIPTION
This is related to the changes made in #421 (the inclusion of "publisherid") and is in the 'object' section for statements. The 'object.id' property is the one now generated by the LMS and is therefore no longer related to the course structure.