### PR TITLE
Switch publisher id handling

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -417,11 +417,11 @@ The AU MUST issue a statement to the LRS prior to termination using the Terminat
 ###7.1.4 Types of Statements
 The statements issued within an AU session could fall within the following categories:
 
-* "cmi5 defined" - Statements using cmi5 defined verbs, category id, and context template.
-* "cmi5 allowed" - Statements using any verb and cmi5 context template (but NOT including cmi5 category id).
+* "cmi5 defined" - Statements using cmi5 defined verbs, category id as defined in section 9.6.2.1, and context template.
+* "cmi5 allowed" - Statements using any verb and cmi5 context template (but NOT including cmi5 category id as defined in section 9.6.2.1).
 * "cmi5 not-allowed" - Any statements not conforming with the cmi5 specification.
 
-The AU MAY issue statements that are defined as "cmi5 allowed" statements per section 9.6.2. If "cmi5 allowed" statements are posted by the AU, they MUST occur between cmi5 statements using the "Initialized" verb and the "Terminated" verb. "cmi5 allowed" statements are not considered in cmi5 defined session management and completion rules.
+If "cmi5 allowed" statements are posted by the AU, they MUST occur between cmi5 statements using the "Initialized" verb and the "Terminated" verb. "cmi5 allowed" statements are not considered in cmi5 defined session management and completion rules.
 
 <a name="content_launch"></a>  
 #8.0 Content Launch Mechanisms
@@ -936,9 +936,7 @@ The purpose of this property is to facilitate searches of the LRS by the LMS or 
 
 <a name="context_activities_category_cmi5"></a>
 ####9.6.2.1 cmi5 Category Activity
-All cmi5 defined statements MUST have an Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" in the "category" context activities list.
-
-All statements that do NOT include an Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" in the "category" context activities list are "cmi5 allowed" statements. An AU MAY issue "cmi5 allowed" statements using cmi5 verbs or verbs defined outside the scope of the cmi5 specification.
+An Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" in the "category" context activities list to be used in cmi5 defined statements as described in section 7.1.4.
 
 <a name="context_activities_category_moveon"></a>
 ####9.6.2.2 moveOn Category Activity

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -80,11 +80,13 @@
   * [9.6 Context](#context)
       * [9.6.1 Registration](#registration)
       * [9.6.2 ContextActivities](#context_activities)
+          * [9.6.2.1 cmi5 Category Activity](#context_activities_category_cmi5)
+          * [9.6.2.2 moveOn Category Activity](#context_activities_category_moveon)
+          * [9.6.2.3 Publisher id Grouping Activity](#context_activities_grouping_publisherid)
       * [9.6.3 Extensions](#extensions)
           * [9.6.3.1 session ID](#context_extensions_session_id)
           * [9.6.3.2 masteryScore](#context_extensions_masteryScore)
           * [9.6.3.3 launchMode](#context_extensions_launchMode)
-          * [9.6.3.4 publisherId](#context_extensions_publisherid)
   * [9.7 Timestamp](#timestamp)
 * [__10.0 xAPI State Data Model__](#xapi_state)
 * [__11.0 xAPI Agent Profile Data Model__](#xapi_agent_profile)
@@ -928,14 +930,23 @@ The value for the registration property used in the context object MUST be the v
 
 <a name="context_activities"></a>
 ###9.6.2 contextActivities
+The purpose of this property is to facilitate searches of the LRS by the LMS or other reporting systems. The "contextActivities" property contains list(s) of Activity objects whose ids can be used as a statement list filter.
 
-The purpose of this property is to facilitate searches of the LRS by the LMS or other reporting systems. contextActivities contain category objects whose entries can be used as wildcard searches.
+<a name="context_activities_category_cmi5"></a>
+####9.6.2.1 cmi5 Category Activity
+All cmi5 defined statements MUST have an Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" in the "category" context activities list.
 
-All cmi5 defined statements MUST have a category with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5".
+All statements that do NOT include an Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" in the "category" context activities list are "cmi5 allowed" statements. An AU MAY issue "cmi5 allowed" statements using cmi5 verbs or verbs defined outside the scope of the cmi5 specification.
 
-All statements that do NOT include a category with an "id" of "https://w3id.org/xapi/cmi5/context/categories/cmi5" are "cmi5 allowed" statements. An AU MAY issue "cmi5 allowed" statements using cmi5 verbs or verbs defined outside the scope of the cmi5 specification.
+<a name="context_activities_category_moveon"></a>
+####9.6.2.2 moveOn Category Activity
+cmi5 defined statements with a Result object (Section 9.5) that include either "success" or "completion" properties MUST have an Activity object with an "id" of "https://w3id.org/xapi/cmi5/context/categories/moveon" in the "category" context activities list. Other statements MUST NOT include this Activity.
 
-Statements with a Result object (Section 9.5) that include either "success" or "completion" properties MUST have a category with an "id" of "https://w3id.org/xapi/cmi5/context/categories/moveon". Other statements MUST NOT include this Activity.
+<a name="context_activities_grouping_publisherid"></a>
+####9.6.2.3 Publisher id Grouping Activity
+Used to identify statements from the AU using the publisher's id from the course structure.
+
+The LMS MUST include an Activity object with an "id" property whose value is the unaltered value of the AU's id attribute from the course structure (See Section 13.1.4 AU Metadata – id) in the "grouping" context activities list in the "contextTemplate" as described in the State API (See Section 10) prior to launching an AU. The LMS MUST also include the publisher id Activity in the "grouping" context activities list for all "cmi5 defined" and "cmi5 allowed" statements it makes directly in the LRS.
 
 <a name="extensions"></a> 
 ###9.6.3 extensions
@@ -986,23 +997,7 @@ The following are extensions specified for cmi5.  Other extensions are permitted
    <tr><th align="right" nowrap>Value space:</th><td>Per launchMode vocabulary defined in section 10.0 xAPI State Data Model</td></tr>
    <tr><th align="right" nowrap>Sample value:</th><td>"Normal"</td></tr>
  </table>
- 
-  <a name="context_extensions_publisherid"></a>
-####9.6.3.4 publisherId
- 
- <table>
-   <tr><th align="right" nowrap>ID:</th><td>https://w3id.org/xapi/cmi5/context/extensions/publisherid</td></tr>
-   <tr><th align="right" nowrap>Description:</th><td>Used to identify the AU using the publisher's id from the course structure. (See Section 13.1.4 AU Metadata – id).</td></tr>
-   <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST record the publisher ID in the State API (See Section 10) prior to launching an AU. The LMS MUST also provide the publisher ID in the context as an extension for all "cmi5 defined" and "cmi5 allowed" statements it makes directly in the LRS.</td></tr>
-   <tr><th align="right" nowrap>AU Usage:</th><td>An AU MUST include the publisher ID provided by the LMS in the context as an extension for all "cmi5 defined" and "cmi5 allowed" statements it makes directly in the LRS.</td></tr>
-   <tr><th align="right" nowrap>AU Obligation:</th><td>Required</td></tr>
-   <tr><th align="right" nowrap>LMS Obligation:</th><td>Required</td></tr>
-   <tr><th align="right" nowrap>Data type:</th><td>String (URL-encoded)</td></tr>
-   <tr><th align="right" nowrap>Value space:</th><td>IRI</td></tr>
-   <tr><th align="right" nowrap>Sample value:</th><td>http://example.com/content/presentation/xyz123/index.html</td></tr>
- </table>
- 
- 
+
 <a name="timestamp"></a> 
 ##9.7 Timestamp
 
@@ -1026,9 +1021,16 @@ An example of the JSON document is shown below.
 ```javascript
 {
   "contextTemplate": {
+    "contextActivities": {
+      "grouping": [
+        {
+          "objectType": "Activity",
+          "id": "<The unaltered value of the AU's id from the course structure>"
+        }
+      ]
+    },
     "extensions": {
-      "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "<The LMS generated session ID value>",
-      "https://w3id.org/xapi/cmi5/context/extensions/publisherid":"<The unaltered value of the AU's id from the course structure>"
+      "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "<The LMS generated session ID value>"
     }
   },
   "launchMode": "<launchMode value>",
@@ -1050,12 +1052,12 @@ The properties for the "LMS.LaunchData" document are described below.
   <tr><th align="right" nowrap>Description:</th><td>Context template for the AU being launched.</td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>Yes</td></tr>
-  <tr><th align="right" nowrap>LMS Usage:</th><td>LMS MUST include a "contextTemplate" object and MUST place all of the following values in that object's "extensions":
-<ul><li>The value for session id placed in the element:<br>&nbsp;"https://w3id.org/xapi/cmi5/results/extensions/session"</li>
-<li>The unaltered value of the AU's id from the course structure (see 13.1.4 AU Metadata) placed in the element:<br>&nbsp; "https://w3id.org/xapi/cmi5/results/extensions/publisherid</li></ul>
+  <tr><th align="right" nowrap>LMS Usage:</th><td>LMS MUST include a "contextTemplate" object and MUST include the following values:
+<ul><li>The value for session id placed in an "extensions" property with the id:<br>&nbsp;"https://w3id.org/xapi/cmi5/results/extensions/session"</li>
+<li>The publisher id Activity as defined in Section 9.6.2.3 in the "contextActivities.grouping" list</li></ul>
 The LMS MAY place additional values in the "contextTemplate".</td></tr>
-  <tr><th align="right" nowrap>AU Usage:</th><td>AU MUST get the contextTemplate value from the "LMS.LaunchData" state document. The AU MUST NOT modify or delete the "LMS.LaunchData" state document. The AU MUST use the contextTemplate as a template for the context property in all xAPI statements it records to the LMS. While the AU may include additional values in the context object of such statements, it MUST NOT overwrite any values provided in the contextTemplate. NOTE: this will include the session ID specified by the LMS.</td></tr>
-  <tr><th align="right" nowrap>Data Type:</th><td>JSON context object as defined in xAPI specification.</td></tr>
+  <tr><th align="right" nowrap>AU Usage:</th><td>AU MUST get the "contextTemplate" value from the "LMS.LaunchData" State document. The AU MUST NOT modify or delete the "LMS.LaunchData" State document. The AU MUST use the contextTemplate as a template for the "context" property in all xAPI statements it records to the LMS. While the AU may include additional values in the Context object of such statements, it MUST NOT overwrite any values provided in the contextTemplate. NOTE: this will include the session id specified by the LMS.</td></tr>
+  <tr><th align="right" nowrap>Data Type:</th><td>JSON Context object as defined in xAPI specification.</td></tr>
 </table>
 
 <table>

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -910,14 +910,16 @@ Sample JSON:
    "context": {
      "registration": "<registration value provided by LMS>",
      "contextActivities": {
-        "category": {[
+        "category": [
           {"id": "https://w3id.org/xapi/cmi5/context/categories/moveon"},
           {"id": "https://w3id.org/xapi/cmi5/context/categories/cmi5"}
-        ]}
+        ],
+        "grouping": [
+          {"id": "<the unaltered value of the AU's id from the course structure>"}
+        ]
      },
      "extensions" {
         "https://w3id.org/xapi/cmi5/context/extensions/sessionid": "<the value of session ID provided by the LMS>",
-        "https://w3id.org/xapi/cmi5/context/extensions/publisherid":"<the unaltered value of the AU's id from the course structure>"
         "https://w3id.org/xapi/cmi5/context/extensions/masteryscore": 0.50,
         "https://w3id.org/xapi/cmi5/context/extensions/launchMode" : "Normal"
       }


### PR DESCRIPTION
* Break context activities description into sub-sections
* Remove publisher id as a context template extension
* Add publisher id Activity as part of context activities 'grouping' list

Fixes issue #431.

The changes include some language change around the xAPI concepts that are being used, specifically it changes the language to indicate that the things going in contextActivities are in fact Activities (they must be per xAPI spec) and that they are going in a specific list (which is the value of the property from the xAPI spec) within that object indicated by a specific property of the object.

I also adjusted the use of language indicating that they can be used as a "wildcard search" mechanism as that really isn't the case. There isn't any facility for say searching for an Activity id of "http://example.edu/*" where the "*" is wildcard notation.