### PR TITLE
Remove incorrect language from launchParameters metadata description

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1612,7 +1612,7 @@ The data in this section are used by the LMS to locate the AU and provide launch
         <strong>Data type: </strong>string </p>
     </td>
     <td width="815" valign="top"><p><strong>Description:</strong><br>
-      Static launch parameters defined by the course designer.  The LMS is required to store this data and provide it to the AU if    requested by the AU during runtime.<br>
+      Static launch parameters defined by the course designer.<br>
       </p>
       <p><strong>Value space:</strong><br>
         Values are defined by the course designer.</p>


### PR DESCRIPTION
Hopefully it is obvious that the LMS must store it, and they are provided in the State API not optionally. If we are going to include language to indicate this we should probably just reference section 10.
