### PR TITLE
Remove "0.1" from revision history text

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -122,7 +122,7 @@ __Sandstone - 1st Edition (May 15, 2015):__
 
 * Developer release
 
-__0.1 Convert Working Draft to Markdown in GitHub (Feb 20, 2013):__  
+__Convert Working Draft to Markdown in GitHub (Feb 20, 2013):__
 
 * Converted existing working draft to markdown format from Microsoft Word. All previous work from 2012 discarded.
 


### PR DESCRIPTION
Looked a little wonky to start with numerical versioning and then to just drop it. If there is a good reason to keep the "0.1" then close this.
