### PR TITLE
Remove extra copyright, update missed one

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -6,12 +6,6 @@
 
 
 ---
->
->Copyright &copy; 2012-2016 ADL, All rights reserved
->
-
-----
-
 
 ## Table of Contents
 
@@ -1719,7 +1713,7 @@ An extended simple course structure example is available in [v1/examples/extende
 <a id="license_agreement"></a> 
 #License Agreement
 
-Copyright 2012-2015 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense
+Copyright &copy; 2012-2016 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense, All rights reserved
 
 Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. 
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Copyrights had gotten out of sync based on recent commit. I don't know of a reason to include it twice so I removed the extra less specific one in favor of the longer one, and updated it with the additional year.
