### PR TITLE
Include publisher ID in the context Activities

### DIFF
--- a/samples/scenarios/01-simple_session/01-satisfied_statement.json
+++ b/samples/scenarios/01-simple_session/01-satisfied_statement.json
@@ -16,7 +16,7 @@
   },
   "object": {
     "objectType": "Activity",
-    "id": "http://course-repository.example.edu/identifiers/courses/02baafcf",
+    "id": "https://examplelms.com/courses/2909s3",
     "definition": {
       "name": {
         "en-US": "Introduction to Geology"
@@ -30,6 +30,12 @@
   "context": {
     "registration": "839b7078-b3f2-499f-8628-d1a83039a375",
     "contextActivities": {
+      "grouping": [
+        {
+          "objectType": "Activity",
+          "id": "http://course-repository.example.edu/identifiers/courses/02baafcf"
+        }
+      ],
       "category": [
         {
           "objectType": "Activity",


### PR DESCRIPTION
Every statement should include the original publisher's ID in the context, and the activity ID sent by the LMS should not match the publisher ID.
