### PR TITLE
Add group of best practices

### DIFF
--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -2,10 +2,11 @@
 ---
 
 # Best Practices
+{% capture tmp %}{% increment bpCount %}{% endcapture %}
 
 ------
 
-### Best Practice #1 – Use of Objectives
+### Best Practice #{% increment bpCount %} – Use of Objectives
 
 (Since Objectives usage outside of course structure is not defined.)
 
@@ -18,7 +19,8 @@ The same Objective can be referenced by multiple AU or Blocks. There are 2 ways 
 
 It is recommended that LMS developers document how they do this and allow for an extension (in the course structure) to indicate what method should be used.
 
-### Best Practice #2 – LMS should always implement the "returnURL"
+### Best Practice #{% increment bpCount %} – LMS should always implement the "returnURL"
+
 LMS should always implement the "returnURL"
 
 LMS should not spawn a new window to launch AU (i.e. “popup”). Depending on the settings it could take the following actions to launch an AU:

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -28,4 +28,9 @@ LMS should not spawn a new window to launch AU (i.e. “popup”). Depending on 
 * **OwnWindow** – Redirect same window to AU location
 * **AnyWindow** – Either redirect same window or use iFrame, “LightBox”, etc.
 
+### Best Practice #{% increment bpCount %} – Fetch URLs
+
+* The Fetch URL should be unique for each session.
+* Do not reuse auth tokens.
+
 ------

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -53,4 +53,16 @@ When creating a course structure, always specify a moveOn criteria for each AU. 
 * If at least one AU has a moveOn criteria specified (other than “NotApplicable”) then the course would be satisfied upon satisfaction of those AU’s.
 * It is considered to be a better practice to explicitly specify the moveOn for each AU in a course structure to ensure there is no confusion over the satisfaction requirements of a course.
 
+### Best Practice #{% increment bpCount %} – Launching apps on mobile devices
+
+One of the following options should be used to launch AU's that are apps on mobile devices:
+
+_Option 1_: Use an app protocol in the launch URL.
+
+* AU is an app.
+* AU has url with a protocol LMS launches App using URL with app protocol.
+* An app redirecting to browser is not useful. If using app protocol to launch, don’t use "returnURL".
+
+_Option 2_: Use and HTML wrapper to launch the app AU is an HTML page (wrapper) that directs from the mobile browser to the app.
+
 ------

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -41,4 +41,8 @@ If the LMS issues a Mastery Score, the AU should respond in the following ways:
 * If the AU does not have scoring or the learner does not meet the Mastery Score then the AU must not issue a Passed Statement (per the specification).
 * The AU can also refuse to execute because the Mastery Score issued is inconsistent with the learning design of the AU. In this situation, the AU should inform the learner why it cannot execute.
 
+### Best Practice #{% increment bpCount %} – LMS Mastery Score
+
+LMS should use caution when adding Mastery Scores to AU course structure entries if they are not present in the original course structure. (As the AU may not be designed to handle scores). It is recommended that such changes be tested prior to enrolling learners.
+
 ------

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -45,4 +45,12 @@ If the LMS issues a Mastery Score, the AU should respond in the following ways:
 
 LMS should use caution when adding Mastery Scores to AU course structure entries if they are not present in the original course structure. (As the AU may not be designed to handle scores). It is recommended that such changes be tested prior to enrolling learners.
 
+### Best Practice #{% increment bpCount %} – Always specify a moveOn criterion in the course structure for each AU
+
+When creating a course structure, always specify a moveOn criteria for each AU. Failing to do so will result in a default of “Not Applicable”. This can have the following unintended consequences:
+
+* When failing to specify moveOn criteria or specifying “NotApplicable” as the moveOn criteria for all AU’s in a course, the course will automatically being marked satisfied immediately upon registration of the learner (before the learner launches a single AU).
+* If at least one AU has a moveOn criteria specified (other than “NotApplicable”) then the course would be satisfied upon satisfaction of those AU’s.
+* It is considered to be a better practice to explicitly specify the moveOn for each AU in a course structure to ensure there is no confusion over the satisfaction requirements of a course.
+
 ------

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -33,4 +33,12 @@ LMS should not spawn a new window to launch AU (i.e. “popup”). Depending on 
 * The Fetch URL should be unique for each session.
 * Do not reuse auth tokens.
 
+### Best Practice #{% increment bpCount %} – AU Mastery Score
+
+If the LMS issues a Mastery Score, the AU should respond in the following ways:
+
+* If the AU has no notion of scoring, it should not issue Passed or Failed statements.
+* If the AU does not have scoring or the learner does not meet the Mastery Score then the AU must not issue a Passed Statement (per the specification).
+* The AU can also refuse to execute because the Mastery Score issued is inconsistent with the learning design of the AU. In this situation, the AU should inform the learner why it cannot execute.
+
 ------

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -25,7 +25,7 @@ LMS should always implement the "returnURL"
 
 LMS should not spawn a new window to launch AU (i.e. “popup”). Depending on the settings it could take the following actions to launch an AU:
 
-* **OwnWindow** – Redirect same window to AU location if Own Window)
-* **AnyWindow** – Either Redirect or use iFrame, or “LightBox”, or etc.
+* **OwnWindow** – Redirect same window to AU location
+* **AnyWindow** – Either redirect same window or use iFrame, “LightBox”, etc.
 
 ------


### PR DESCRIPTION
Fixes #521, #522, #523, #524, #525, #526, #527.

Wording is taken either from the original issue or where specified in [meeting minutes from 11/04/2016](https://github.com/AICC/CMI-5_Spec_Current/wiki/CMI-5-Working-Group-Meeting-Minutes-%E2%80%93-November-4th%2C-2016) with some minor adjustments for wording.

One notable change is from the use of "completion" to "satisfaction" when talking about `moveOn` criteria at the course level.

Additionally the first commit is for handling the dynamic updating of the best practice numbering so that if/when they are either moved around or deleted the numbering scheme will not break. This will unfortunately break deep linking, etc. and it might be worth considering whether we really want numbering at all. 

I broke the individual inclusions into separate commits to make it possible to work with them at a git level but left it as a single pull request because otherwise the order of merge isn't pre-determined and we'd likely just end up with a whole lot of conflict resolution work which would just be a waste of time. I'm happy to address either whole PR comments or per commit comments.

View what the page will look like after merge at http://brianjmiller.github.io/CMI-5_Spec_Current/best_practices/