### PR TITLE
Clarify Duration Calculation

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -801,7 +801,7 @@ The AU MUST include the "duration" property in "Failed" statements. The AU SHOUL
 <a name="lms_statements_that_include_duration"></a>
 #### 9.5.4.2 LMS statements that include duration
 ##### Abandoned Statement
-The duration property MUST be included in "Abandoned" statements. The duration property MUST, at a minimum, be set as the total session time, calculated as the time between the "Launched" statement and the last statement (of any kind) issued by the AU. The LMS SHOULD also use other (LMS specific) methods (if available) to determine if the total session time was longer.
+The duration property MUST be included in "Abandoned" statements. The LMS SHOULD use LMS specific methods (if available) to determine the duration if it has more accurate means of session time calculation than time stamp differences between statements. In the absence of such methods, the duration property MUST be set as the total session time, calculated as the time between the "Launched" statement and the last statement (of any kind) issued by the AU. 
 
 <a name="result_extensions"></a>
 ### 9.5.5 Extensions


### PR DESCRIPTION
**_Clarify Duration Calculation - Per Aug 18th meeting_**

> **9.5.4.2 LMS statements that include duration**

> **Abandoned Statement**

> The duration property MUST be included in "Abandoned" statements. 
> The LMS SHOULD use LMS specific methods (if available) to determine the duration if it has more accurate means of session time calculation than time stamp differences between statements.
> In the absence of such methods, the duration property MUST be set as the total session time, calculated as the time between the "Launched" statement and the last statement (of any kind) issued by the AU. 