### PR TITLE
cmi5 spec errata - launchMode (per Apr 12 meeting)

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1022,9 +1022,9 @@ The LMS MAY place additional values in the "contextTemplate".</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>LMS Usage:</th><td>LMS MUST include a value for <strong><em>launchMode</em></strong>.</td></tr>
   <tr><th align="right" nowrap>AU Usage:</th><td>The AU MUST conform to the following based on the value of <strong><em>launchMode</em></strong><br>
-      <ul><li>Normal<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST record other cmi5 verb statements per the requirements defined in section 9.3 – Verbs.</li>
-      <li>Browse<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST NOT record other cmi5 verb statements.</li>
-      <li>Review<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST NOT record other cmi5 verb statements.</li></ul></td></tr>
+      <ul><li>Normal<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST record other cmi5 defined statements per the requirements defined in section 9.3 – Verbs.</li>
+      <li>Browse<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST NOT record other cmi5 defined statements.</li>
+      <li>Review<br>The AU MUST record "Initialized" and "Terminated" verb statements.  The AU MUST NOT record other cmi5 defined statements.</li></ul></td></tr>
   <tr><th align="right" nowrap>Data Type:</th><td>String</td></tr>
   <tr><th align="right" nowrap>Value Space:</th><td>"Normal", "Browse", or "Review"</td></tr>
   <tr><th align="right" nowrap>Sample Value:</th><td>"Normal"</td></tr>


### PR DESCRIPTION
As per the Apr 12 meeting,  more clearly indicate cmi5 defined statements in section 10.0 xAPI State Data Model for launchMode - AU Usage