### PR TITLE
Indicate at least one AU in section 5.0

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -309,7 +309,7 @@ Course structure data MUST NOT implement any features or functionality (optional
 # 5.0 Conceptual Model: Informative  
 
 Synopsis of the cmi5 model:
-* An LMS imports a course structure, which may contain one or more AUs.  Optionally, the course structure may include one or more blocks, which consist of 1 or more AUs or nested blocks.
+* An LMS imports a course structure which contains at least one AU.  Optionally, the course structure may include one or more blocks, which consist of 1 or more AUs or nested blocks.
 * An LMS administrative user assigns a course to a learner.
 * A learner authenticates with an LMS or a related system.
 * A learner launches an AU from the LMS or an associated launching system, using an interface.


### PR DESCRIPTION
Using "may" in the original followed by "one or more" implies that a course structure could have no AUs when at least one is required. Additionally this isn't framed as "requirement" language so the removal of "may" prevents the expectation that this would become a MAY.