### PR TITLE
8.1 clarify requirement for AnyWindow launchMethod

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -421,7 +421,7 @@ When the launchMethod is "OwnWindow", the LMS MUST use one of the following:
 * Spawning a new browser window for the AU.
 * Re-directing the existing browser window to the AU.
 
-When the launchMethod is "AnyWindow", the LMS may choose the window context of the AU.  All browser window options are acceptable - Frameset, New window, browser redirect, etc.
+When the launchMethod is "AnyWindow", the LMS MUST choose the window context of the AU.  All browser window options are acceptable - Frameset, New window, browser redirect, etc.
 
 In either case, the AU MUST be launched by the LMS with a URL having query string launch parameters as defined in this section. The launch parameters MUST be name/value pairs in a query string appended to the URL that launches the AU.
 


### PR DESCRIPTION
This makes the language (and requirements) more consistent with that of `OwnWindow` directly above it.

This can be a MUST because there isn't really an alternative, the LMS (or at least the thing using the launchUrl) has to put it somewhere.