### PR TITLE
Improve language around use of "actor"

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -580,7 +580,7 @@ The AU MUST assign a statement id property in UUID format (as defined in the xAP
   
 <a name="actor" ></a>
 ## 9.2 Actor
-The Actor property will be defined by the LMS. The Actor property for all "cmi5 defined" statements MUST be of objectType "Agent" and MUST contain an "account" as defined in the xAPI specification.
+The Actor property will be defined by the LMS. The Actor property for all "cmi5 defined" statements MUST be of objectType "Agent". The Actor property MUST contain an "account" IFI as defined in the xAPI specification.
 
 <a name="verbs" ></a> 
 ## 9.3 Verbs  


### PR DESCRIPTION
* Split combined requirements into two separate sentences to make it easier to list them.
* Include that the account is an IFI.