### PR TITLE
Make Verb requirements more explicit

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -602,13 +602,13 @@ AU Verb Ordering Rules within an AU session are as follows:
 * The "Terminated" verb MUST be the last statement (cmi5 allowed or defined).
 
 AU Verb Ordering Rules within a Registration (per AU) are as follows:
-* Only one "Completed" cmi5 defined statement is allowed per registration.
-* Only one "Passed" cmi5 defined statement is allowed per registration.
-* A "Failed" statement must not follow a "Passed" statement (in cmi5 defined statements) per registration.
+* More than one "Completed" cmi5 defined statement MUST NOT be used per registration.
+* More than one "Passed" cmi5 defined statement MUST NOT be used per registration.
+* A "Failed" statement MUST NOT follow a "Passed" statement (in cmi5 defined statements) per registration.
 
 AUs may use additional verbs not listed in this specification.
 
-Regardless of the verbs the AUs use in statements, the LMS MUST record and provide reporting for all statements. 
+The LMS MUST record and provide reporting for all statements regardless of the verbs used in statements sent by AUs. 
 
 LMS verb ordering rules are as follows:
 * LMS may issue multiple satisfied statements (in a session).

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -603,7 +603,7 @@ AU Verb Ordering Rules within an AU session are as follows:
 
 AU Verb Ordering Rules within a Registration (per AU) are as follows:
 * More than one "Completed" cmi5 defined statement MUST NOT be used per registration.
-* More than one "Passed" cmi5 defined statement MUST NOT be used per registration.
+* Exactly zero or one "Passed" cmi5 defined statement MUST be used per registration.
 * A "Failed" statement MUST NOT follow a "Passed" statement (in cmi5 defined statements) per registration.
 
 AUs may use additional verbs not listed in this specification.

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -602,7 +602,7 @@ AU Verb Ordering Rules within an AU session are as follows:
 * The "Terminated" verb MUST be the last statement (cmi5 allowed or defined).
 
 AU Verb Ordering Rules within a Registration (per AU) are as follows:
-* More than one "Completed" cmi5 defined statement MUST NOT be used per registration.
+* Exactly zero or one "Completed" cmi5 defined statement MUST be used per registration.
 * Exactly zero or one "Passed" cmi5 defined statement MUST be used per registration.
 * A "Failed" statement MUST NOT follow a "Passed" statement (in cmi5 defined statements) per registration.
 


### PR DESCRIPTION
The "More than one" language is more consistent with what is in the list above and provides the ability to include `MUST NOT` as the requirement rather than saying "is allowed".

The second change just moves the emphasis to the LMS requirement at the beginning of the sentence.