### PR TITLE
Adjust LMS obligations and usage for Passed

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -657,8 +657,8 @@ LMS verb ordering rules are as follows:
 <tr><th align="left">ID</th><td>http://adlnet.gov/expapi/verbs/passed</td></tr>
 <tr><th align="left">Description</th><td>The learner attempted and succeeded in a judged activity in the AU.</td></tr>
 <tr><th align="left" nowrap>AU Obligations</th><td>The AU MUST send a statement containing the "Passed" verb when the learner has attempted and passed the AU. If the "Passed" statement contains a (scaled) score, the (scaled) score MUST be equal to or greater than the "masteryScore" indicated in the LMS Launch Data. (See xAPI State Data Model, Section 10.0 - masteryScore). The AU MUST NOT issue multiple statements with "Passed" for the same AU within a given course registration for a given learner.</td></tr>
-<tr><th align="left" nowrap>LMS Obligations</th><td>The LMS MUST use either "Passed" or "Completed" statements (or both) based on the "moveOn" criteria for the AU as provided in the LMS Launch Data. (See xAPI State Data Model, Section 10.0 - moveOn).</td></tr>
-<tr><th align="left">Usage</th><td>The AU MUST send a statement containing the "Passed" verb when the learner has attempted and successfully passed the judged activity.</td></tr>
+<tr><th align="left" nowrap>LMS Obligations</th><td>The LMS MUST use "Passed" statements based on the "moveOn" criteria for the AU as provided in the LMS Launch Data. (See xAPI State Data Model, Section 10.0 - moveOn).</td></tr>
+<tr><th align="left">Usage</th><td>The criterion for "Passed" is determined by the course designer.</td></tr>
 </table>
 
 <a name="verbs_failed"></a>


### PR DESCRIPTION
This limits the "LMS Obligations" to only talk about the verb from the section, that is "Passed", which needs to be combined with #655 . Additionally this adjusts the "Usage" to match that of "Completed" and eliminates what seems to be a duplicated requirement that is already under "AU Obligations" though with slightly different wording.