### PR TITLE
Adjust language in Context

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -853,7 +853,7 @@ The duration property MUST be included in "Abandoned" statements. The LMS SHOULD
 <a name="context"></a> 
 ## 9.6 Context
 
-All cmi5 defined statements MUST contain a context that includes all objects/values as defined in this section. Either the LMS or the AU MAY provide additional objects.
+All cmi5 defined statements MUST contain a context that includes all objects/values as defined in this section. Either the LMS or the AU MAY provide additional properties.
 
 <a name="registration"></a> 
 ### 9.6.1 registration

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -853,7 +853,7 @@ The duration property MUST be included in "Abandoned" statements. The LMS SHOULD
 <a name="context"></a> 
 ## 9.6 Context
 
-All cmi5 defined statements MUST contain a context that includes all objects/values as defined in this section. Either the LMS or the AU MAY provide additional properties.
+All cmi5 defined statements MUST contain a context that includes all properties as defined in this section. Either the LMS or the AU MAY provide additional properties.
 
 <a name="registration"></a> 
 ### 9.6.1 registration


### PR DESCRIPTION
"Objects" aren't really added to the `context`. Additional properties are available within that object based on xAPI. If this was intended to be specifically about the lists in `context.contextActivities` we should probably either add a requirement that is specifically for that section that talks about appending the objects to any of the lists, or move the requirement there if we didn't mean to indicate additional properties could be added (which is unlikely).