### PR TITLE
Reorder launchParameters State requirement

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1032,7 +1032,7 @@ The LMS MAY place additional values in the "contextTemplate".</td></tr>
 <table>
   <tr><th colspan="2" align="left">launchParameters</th></tr>
   <tr><th align="right" nowrap>Description:</th><td>The <strong><em>launchParameters</em></strong> defined in the cmi5 Course Structure.</td></tr>
-  <tr><th align="right" nowrap>LMS Required:</th><td>If the <strong><em>launchParameters</em></strong> were defined by the course designer in the Course Structure, the LMS MUST include the  <strong><em>launchParameters</em></strong> in the State API document.</td></tr>
+  <tr><th align="right" nowrap>LMS Required:</th><td>The LMS MUST include the  <strong><em>launchParameters</em></strong> in the State API document if the <strong><em>launchParameters</em></strong> were defined by the course designer in the Course Structure.</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>No</td></tr>
   <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST provide a <strong><em>launchParameters</em></strong> value in the state API document. The <em>launchParameters</em> value written in the State API Document MAY be different than the one in the course structure (e.g. based on content vendor options that may be used by the LMS admin users).</td></tr>
   <tr><th align="right" nowrap>AU Usage:</th><td>The AU SHOULD get the <strong><em>launchParameters</em></strong> value from the State API document if the launch parameters were defined in the Course Structure.</td></tr>


### PR DESCRIPTION
This just reorders the requirement **but** it should be reconciled against #636 which points out that there are potentially duplicative requirements that are conflicting.