### PR TITLE
Adjust entitlementKey language

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1081,7 +1081,7 @@ The LMS MAY place additional values in the "contextTemplate".</td></tr>
   <tr><th align="right" nowrap>Description:</th><td>The <strong>entitlementKey</strong> object is used by the AU to determine if the launching LMS is entitled to use the AU.</td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>No</td></tr>
-  <tr><th align="right" nowrap>LMS Usage:</th><td>If an entitlementKey is present in the Course Structure for the AU, the LMS MUST add and an entitlementKey object to the LMS.launchdata state document. The entitlementKey consists of 2 properties, “courseStructure” and “alternate”. See items below for LMS usage requirements.</td></tr>
+  <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST add an <strong><em>entitlementKey</em></strong> object to the "LMS.LaunchData" state document if an <strong><em>entitlementKey</em></strong> is present in the Course Structure for the AU. The entitlementKey consists of 2 properties, “courseStructure” and “alternate”. See items below for LMS usage requirements.</td></tr>
   <tr><th align="right" nowrap>AU Usage:</th><td>The AU SHOULD use this data in combination with other data provided from the LMS to determine entitlement.</td></tr>
   <tr><th align="right" nowrap>Data Type:</th><td>JSON Object</td></tr>
   <tr><th align="right" nowrap>Value Space:</th><td>The value for entitlementKey properties are defined by the AU provider.</td></tr>
@@ -1091,7 +1091,7 @@ The LMS MAY place additional values in the "contextTemplate".</td></tr>
 
 <table>
   <tr><th colspan=2 align="left">entitlementKey: courseStructure</th></tr>
-  <tr><th align="right" nowrap>Description:</th><td>The <strong>courseStructure</strong> property contains the value for entitlementKey from the Course Structure. The courseStructure values may be used by the AU to determine if the launching LMS is entitled to use the AU.</td></tr>
+  <tr><th align="right" nowrap>Description:</th><td>The <strong>courseStructure</strong> property contains the value for entitlementKey from the Course Structure. The courseStructure values MAY be used by the AU to determine if the launching LMS is entitled to use the AU.</td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>No</td></tr>
   <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST obtain this from the Course Structure.</td></tr>
@@ -1103,7 +1103,7 @@ The LMS MAY place additional values in the "contextTemplate".</td></tr>
 
 <table>
   <tr><th colspan=2 align="left">entitlementKey: alternate</th></tr>
-  <tr><th align="right" nowrap>Description:</th><td>The <strong>alternate</strong> property is data from some other source as agreed upon between the LMS and the AU. The alternate property values may be used by the AU to determine if the launching LMS is entitled to use the AU.</td></tr>
+  <tr><th align="right" nowrap>Description:</th><td>The <strong>alternate</strong> property is data from some other source as agreed upon between the LMS and the AU. The alternate property values MAY be used by the AU to determine if the launching LMS is entitled to use the AU.</td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>No</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>No</td></tr>
   <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST obtain the value for the alternate property from a source as agreed upon with the AU.</td></tr>


### PR DESCRIPTION
Reorder, add HTML tags around property name, correct "add and" typo, and correctly capitalize `LMS.LaunchData`, capitalize MAYs