### PR TITLE
Indicate Block and Objective ids must be unique

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1256,7 +1256,7 @@ The data in this section are used for the block structures with group AUs.  A Bl
   <tr>
     <td width="164" valign="top"><p><strong>Required: </strong> Yes<br>
         <strong>Data type: </strong> IRI</p></td>
-    <td width="811" valign="top"><p><strong>Description: </strong>A globally unique IRI to identify the Block in xAPI requests made by the LMS.</p>
+    <td width="811" valign="top"><p><strong>Description: </strong>A globally unique IRI to identify the Block in xAPI requests made by the LMS. This id MUST be unique within the course structure.</p>
       <p><strong>Value space: </strong>Values defined by course designer</p>
       <p><strong>Sample value:</strong><br>
       &lt;block id="http&#58;//www.example.com/identifiers/aublock/005430bf-b3ba-45e6-b47b-d629603d83d8" &gt; &hellip; &lt;/block&gt;
@@ -1335,7 +1335,7 @@ The data in this section are used by the Objectives. Objectives can be associate
         <strong>Data type:</strong> IRI</p>
     </td>
     <td width="792" valign="top"><p><strong>Description:</strong><br>
-      A unique IRI for the learning objective.<br>
+      A unique IRI for the learning objective. This id MUST be unique within the course structure.<br>
       </p>
       <p><strong>Value space:</strong><br>Values are defined by the course designer.</p>
     <p><strong>Sample value:</strong><br>


### PR DESCRIPTION
The wording:

> This id MUST be unique within the course structure.

Comes from that used by the AU id cell. This is an assumed requirement by me so the group should confirm that it is in fact expected that block ids and/or objective ids are intended to only be allowed once in a course structure. I suppose there is a case where a block could have a repeated id within a subsequent block or similar and that at that point one could hope to leverage the hierarchical structure to understand that block's role in the overall scheme. This feels tenuous at best.

This should not be read as expecting an objective to only be referenced a single time, this is for the top level element that lists the objectives that may then be used elsewhere in the course structure file.