### PR TITLE
The AU id is defined by the publisher id

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1432,8 +1432,8 @@ The data in this section are used by the LMS to locate the AU and provide launch
     <td width="160" valign="top"><p><strong>Required: </strong> Yes<br>
         <strong>Data type: </strong> IRI</p>
     </td>
-    <td width="815" valign="top"><p><strong>Description: </strong>A globally unique IRI defined by content creator/publisher that the AU uses to identify itself in xAPI statement contexts. This id MUST be unique within the course structure.</p>
-      <p><strong>Value space: </strong>Values are defined by the course designer.</p>
+    <td width="815" valign="top"><p><strong>Description: </strong>A globally unique IRI defined by AU publisher that the AU uses to identify itself in xAPI statement contexts. This id MUST be unique within the course structure.</p>
+      <p><strong>Value space: </strong>Values are defined by the AU publisher.</p>
       <p><strong>Sample value:</strong><br>
       &lt;au id="http&#58;//www.example.com/identifiers/activity/005430bf-b3ba-45e6-b47b-d629603d83d2" &gt; &hellip; &lt;/au&gt;
       </p>


### PR DESCRIPTION
This is potentially a spec change.

The roles of AU publisher and course author seem to be distinct in some place and not in others. However I am fairly sure that the AU publisher ID should not be set by the course designer (unless of course one person has both roles).

@brianjmiller and @cawerkenthin I would appreciate your thoughts on it, since I am not aware of the original intention of the quartz spec. If it is simpler and quicker we can discuss on the working group call.