### PR TITLE
 issue #629  -  9.3.9 Satisfied - Block/Course id

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -732,13 +732,9 @@ LMS verb ordering rules are as follows:
 <tr><th align="left">Description</th><td>The verb "Satisfied" indicates that the LMS has determined that the Learner has met the moveOn criteria of all AU's in a block or has met the moveOn criteria for all AU's in the course.</td></tr>
 <tr><th align="left" nowrap>AU Obligations</th><td>None</td></tr>
 <th align="left" nowrap>LMS Obligations</th><td>
-The LMS MUST use the "Satisfied" statement when the learner has met the moveOn criteria of all AU's in a block.  In this statement the LMS MUST use the LMS generated block id as the Object id (Section 9.4 - Object) and use "https://w3id.org/xapi/cmi5/activitytype/block" as the value of the "type" property in the Object's Definition.<br>
+The LMS MUST use the "Satisfied" statement when the learner has met the moveOn criteria of all AU's in a block.  In this statement the LMS MUST use the LMS block id per Section 9.4 and use "https://w3id.org/xapi/cmi5/activitytype/block" as the value of the "type" property in the Object's Definition.<br>
 <br>
-The LMS MUST generate a unique block id for the "Satisfied" Statement. The generated Block id MUST NOT match the publisher’s ID from the course structure.<br>
-<br>
-The LMS MUST also use the "Satisfied" statement when the learner has met the moveOn criteria for all AU's in a course.  In this statement the LMS MUST use the LMS generated course id as the Object id (Section 9.4 - Object) and use "https://w3id.org/xapi/cmi5/activitytype/course" as the value of the "type" property in the Object's Definition.<br>
-<br>
-The LMS MUST generate a unique course id for the "Satisfied" Statement. The generated course id MUST NOT match the publisher’s ID from the course structure.<br>
+The LMS MUST also use the "Satisfied" statement when the learner has met the moveOn criteria for all AU's in a course. In this statement the LMS MUST use the LMS course id per Section 9.4 and use "https://w3id.org/xapi/cmi5/activitytype/course" as the value of the "type" property in the Object's Definition.<br>
 <br>
 The LMS MUST use the session id from the AU launch for all "Satisfied" statements triggered as a result of an AU launch session.<br>
 <br>
@@ -759,6 +755,11 @@ An Object MUST be present, as specified in this section, in all "cmi5 defined" s
 Except for Statements with the Satisfied verb, the Object in a cmi5 defined statement represents the AU.  When the Object is the AU, the value of the Object's "id" property for a given AU MUST match the activityId defined in the launch URL.
 
 In Satisfied statements, the Object represents a Block or Course.  (see 9.3.9 - Satisfied)  
+
+In Satisfied statements for blocks, the LMS MUST use the LMS generated block id as the Object id. The LMS MUST use the same block id for all Satisfied statements that refer to that block.
+
+In Satisfied statements for courses, the LMS MUST use the LMS generated course id as the Object. The LMS MUST use the same course id for all Satisfied statements that reference that course.
+
 
 <a name="result"></a> 
 ## 9.5 Result


### PR DESCRIPTION
Per June 11th meeting - add the following changes to 9.4 and 9.3.9 to address issue #629  -  9.3.9 Satisfied - Block/Course id generation wording should be improved