### PR TITLE
Remove new line and indention from description in sample course

### DIFF
--- a/v1/examples/simple-cmi5.xml
+++ b/v1/examples/simple-cmi5.xml
@@ -6,8 +6,7 @@
     </title>
     <description>
       <langstring lang="en-US">
-        This course will introduce you into the basics of geology. This includes subjects such as
-        plate tectonics, geological materials and the history of the Earth.
+        This course will introduce you into the basics of geology. This includes subjects such as plate tectonics, geological materials and the history of the Earth.
       </langstring>
     </description>
   </course>
@@ -17,8 +16,7 @@
     </title>
     <description>
       <langstring lang="en-US">
-        This course will introduce you into the basics of geology. This includes subjects such as
-        plate tectonics, geological materials and the history of the Earth.
+        This course will introduce you into the basics of geology. This includes subjects such as plate tectonics, geological materials and the history of the Earth.
       </langstring>
     </description>
     <url>http://course-repository.example.edu/identifiers/courses/02baafcf/aus/4c07/launch.html</url>


### PR DESCRIPTION
Should be reviewed with #712

The new lines in this XML would need to be transformed in some way in order to make them valid for inserting into JSON. 

XML can contain newlines, JSON cannot. JSON can contain a newline escape sequence.

It probably doesn't make sense to line wrap the text in the XML course definition.