### PR TITLE
Remove AU termination implementation suggestions

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -403,14 +403,7 @@ The AU MUST issue a statement to the LRS after being launched, initialized, and 
 ### 7.1.2 Last Statement Call
 The AU MUST issue a Terminated statement to the LRS as described in Section 9.3.8 as the last statement in a session.
  
-Once the AU has determined that the session will end (e.g. by user action or some other means) the AU SHOULD issue a Terminated statement.
- 
- Circumstances under which the AU may determine that the session is ending could include:
- 
-* Monitoring for browser window or application close events
-* An AU defined user action for closing the AU session
-* Other AU defined events such as a timeout from user inactivity
-
+Once the AU has determined that the session will end (e.g. by user action, timeout or some other means) the AU SHOULD issue a Terminated statement.
 
 <a name="type_statement_au"></a>  
 ### 7.1.3 Types of Statements


### PR DESCRIPTION
This is my interpretation of a suggestion by @cawerkenthin to address some of this issues discussed in #714 

The specification should not make implementation suggestions.