### PR TITLE
Update to best practice #1

### DIFF
--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -10,7 +10,7 @@
 
 (Since Objectives usage outside of course structure is not defined.)
 
-Objectives are defined for the course structure, but there is no language in the specification concerning their usage in statements. If an AU is using Objectives in statements, the best practice is to add the objective (with the same objective id provided in the course structure) to the context activities “grouping” property as an activity type of `http://adlnet.gov/expapi/activities/objective` from the ADL vocabulary.
+Objectives are defined for the course structure, but there is no language in the specification concerning their usage in statements. If an AU is using Objectives in statements, the best practice is to add the objective (with the same objective id provided in the course structure) to the context activities “parent” property as an activity type of `http://adlnet.gov/expapi/activities/objective` from the ADL vocabulary.
 
 ### Best Practice #{% increment bpCount %} – LMS should always implement the "returnURL"
 

--- a/best_practices/index.md
+++ b/best_practices/index.md
@@ -10,7 +10,7 @@
 
 (Since Objectives usage outside of course structure is not defined.)
 
-Objectives are defined for the course structure, but there is no language in the specification concerning their usage in statements. If an AU is using Objectives in statements, the best practice is to add the objective (with the same objective id provided in the course structure) to the context activities “parent” property as an activity type of (http://adlnet.gov/expapi/activities/objective) from the ADL vocabulary.
+Objectives are defined for the course structure, but there is no language in the specification concerning their usage in statements. If an AU is using Objectives in statements, the best practice is to add the objective (with the same objective id provided in the course structure) to the context activities “grouping” property as an activity type of `http://adlnet.gov/expapi/activities/objective` from the ADL vocabulary.
 
 ### Best Practice #{% increment bpCount %} – LMS should always implement the "returnURL"
 


### PR DESCRIPTION
Switches BP 1 from including objectives in `parent` to including them in `grouping` and removes parenthetical around the activity type to be used and codifies it instead

Fixes #740 