### PR TITLE
#773 1.2 document style conventions

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -227,18 +227,32 @@ This document refers to properites in text descriptions  (ADD TO THIS)
 
 This document uses the following style conventions:
 
-* **Back Ticks ( ` )** – (possibly rendered as “inline code”) for all literal names of verbs and properties – ‘completed’ verb
- - do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)
-* **Double Quotes for shorthand** – the “completed” statement (as described in above)
+* **Back Ticks ( `` )** (rendered as “inline code”) for all literal names of verbs and properties 
+ * *do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)*
+* **Double Quotes ( " ) for shorthand** – the “completed” statement (as described in above)
 * **Literal syntax case** – When referring to verbs and properties the case will show as they appear in xAPI statements
-* **Section Titles with verbs/properties** – may use either Capitalized or Literal
+* **Section Titles with verbs/properties** – may use either Capitalized or Literal syntax.
 
 **Style Usage examples**
-* the ‘score’ property
-* for ‘score’ when….
-* The ‘fetch’ parameter contains a URL value that is used to….
-* The “fetch” URL = The shorthand Concept of 
-* The ‘fetch’ query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
+* **Back Ticks ( `` )**
+ * the ‘score’ property
+    for `score` when….  
+
+* **Double Quotes ( " )**
+ * the 'completed' statement
+     the "completed" statement must
+
+* **Literal syntax case**
+ *
+
+* **Section Titles with verbs/properties**	
+ * 
+
+* **All styles together**
+* The ‘fetch’ parameter contains a URL value that is used to….  
+> The `fetch` query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
+
+
 
 <a name="references"></a> 
 # 2.0  References

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -207,13 +207,11 @@ Other uses of the xAPI specification are outside of this scope.
 Uses of activities not explicitly defined above are outside of the scope of this specification.
 
 <a name="Document_Style_Conventions"></a>  
-## 1.2 Document Style Conventions
-
-The following is proposed language to express the document style conventions.  (e.g. a "how to read this document")
+## 1.2 Document Style Conventions  
 
  **References to Statements**
 
-This document uses, as shorthand, specific vocabulary such as verbs in conjunction with the word "statement" (e.g., a "completed" statement). This shorthand refers to that statement meeting all requirements that would accompany the correct use of that concept. When using this shorthand with the word “the”, this means the cmi5 defined version of that statement with the verb’s display property. (see Section 7.1.3 Types of Statements (#type_statement_au) for the definition of cmi5 defined)
+This document uses, as shorthand, specific vocabulary such as verbs in conjunction with the word "statement" (e.g., a "completed" statement). This shorthand refers to that statement meeting all requirements that would accompany the correct use of that concept. When using this shorthand with the word “the”, this means the cmi5 defined version of that statement with the verb’s display property. (see [Section 7.1.3 Types of Statements](#type_statement_au) for the definition of cmi5 defined)
 
 For example:
 
@@ -240,10 +238,10 @@ This document uses the following style conventions:
 * **Literal syntax case example. The actor object with an object type of agent:**  
 	The actor object with an objectType of Agent
 
-* **Section Titles with verb example. 	See Section 9.3.1 launched:**	
+* **Section Titles with verb example. 	See Section 9.3.1 launched:** 	
 	9.3.1 Launched
 
-* **Section Titles with properties example. 	See Section 9.5.4 duration:**	
+* **Section Titles with properties example. 	See Section 9.5.4 duration:**	 
 	9.5.4 Duration
 
 <a name="references"></a> 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -228,18 +228,18 @@ This document refers to properites in text descriptions  (ADD TO THIS)
 This document uses the following style conventions:
 
 * **Back Ticks ( ` )** (rendered as “inline code”) for all literal names of verbs and properties 
- * *do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)*
+	* *do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)*
 * **Double Quotes ( " ) for shorthand** – the “completed” statement (as described in above)
 * **Literal syntax case** – When referring to verbs and properties the case will show as they appear in xAPI statements
 * **Section Titles with verbs/properties** – may use either Capitalized or Literal syntax.
 
 **Style Usage examples**
-* **Back Ticks ( `` )**
+* **Back Ticks ( ` )**
  * the ‘score’ property  
     for `score` when….  
 
 * **Double Quotes ( " )**
- * the 'completed' statement  
+	* the 'completed' statement  
 
     the "completed" statement must
 
@@ -251,6 +251,7 @@ This document uses the following style conventions:
 
 * **All styles together**
 * The ‘fetch’ parameter contains a URL value that is used to….  
+
 > The `fetch` query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
 
 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -221,41 +221,30 @@ For example:
 
 Would be a cmi5 defined xAPI statement with a verb display name of ‘completed’ and a verb IRI of ‘http://adlnet.gov/expapi/verbs/completed’.  Similar conventions might be used for other xAPI properties.
 
-**References to Properties**
-
-This document refers to properites in text descriptions  (ADD TO THIS)
-
 **Style Conventions**  
 This document uses the following style conventions:
 
-* **Back Ticks ( ` )** (rendered as “inline code”) for all literal names of verbs and properties 
-	* *do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)*
-* **Double Quotes ( " ) for shorthand** – the “completed” statement (as described in above)
-* **Literal syntax case** – When referring to verbs and properties the case will show as they appear in xAPI statements
-* **Section Titles with verbs/properties** – may use either Capitalized or Literal syntax.
+* **Back Ticks ( \` )** – (rendered as "inline code depending on document rendering”) for all literal names of verbs and properties.  
+* **Double Quotes ( " ) for shorthand** – the “completed” statement (as described in above).  
+* **Literal syntax case**  – for referring to verbs and properties the case will show as they appear in xAPI statements. 
+* **Section Titles with verbs/properties** – may use either Capitalized or Literal syntax.  
 
-**Style Usage examples**
-* **Back Ticks ( ` )**
-	* the ‘score’ property  
+**Style Usage examples**  
+
+* **Back Ticks ( \` ) example. The ‘score’ property:**
 	for `score` when….  
+	
+* **Double Quotes ( " ) example. The ‘completed‘ statement:**  
+	the "completed" statement  MUST  
 
-* **Double Quotes ( " )**
-	* the 'completed' statement  
+* **Literal syntax case example. The actor object with an object type of agent:**  
+	The actor object with an objectType of Agent
 
-	the "completed" statement must
+* **Section Titles with verb example. 	See Section 9.3.1 launched:**	
+	9.3.1 Launched
 
-* **Literal syntax case**
- *
-
-* **Section Titles with verbs/properties**	
- * 
-
-* **All styles together**
-	* The ‘fetch’ parameter contains a URL value that is used to….  
-
-	> The `fetch` query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
-
-
+* **Section Titles with properties example. 	See Section 9.5.4 duration:**	
+	9.5.4 Duration
 
 <a name="references"></a> 
 # 2.0  References

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -229,7 +229,7 @@ This document uses the following style conventions:
 
 **Style Usage examples**  
 
-* **Back Ticks ( \` ) example. The ‘score’ property:**
+* **Back Ticks ( \` ) example. The ‘score’ property:**  
 	for `score` when….  
 	
 * **Double Quotes ( " ) example. The ‘completed‘ statement:**  

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -238,10 +238,10 @@ This document uses the following style conventions:
 * **Literal syntax case example. The actor object with an object type of agent:**  
 	The actor object with an objectType of Agent
 
-* **Section Titles with verb example. 	See Section 9.3.1 launched:** 	
+* **Section Titles with verb example. 	See [Section 9.3.1 Launched](#verbs_launched):** 	
 	9.3.1 Launched
 
-* **Section Titles with properties example. 	See Section 9.5.4 duration:**	 
+* **Section Titles with properties example. 	See [Section 9.5.4 Duration](#duration):**	 
 	9.5.4 Duration
 
 <a name="references"></a> 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -227,7 +227,7 @@ This document refers to properites in text descriptions  (ADD TO THIS)
 
 This document uses the following style conventions:
 
-* **Back Ticks ( `` )** (rendered as “inline code”) for all literal names of verbs and properties 
+* **Back Ticks ( ` )** (rendered as “inline code”) for all literal names of verbs and properties 
  * *do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)*
 * **Double Quotes ( " ) for shorthand** – the “completed” statement (as described in above)
 * **Literal syntax case** – When referring to verbs and properties the case will show as they appear in xAPI statements
@@ -235,12 +235,13 @@ This document uses the following style conventions:
 
 **Style Usage examples**
 * **Back Ticks ( `` )**
- * the ‘score’ property
+ * the ‘score’ property  
     for `score` when….  
 
 * **Double Quotes ( " )**
- * the 'completed' statement
-     the "completed" statement must
+ * the 'completed' statement  
+
+    the "completed" statement must
 
 * **Literal syntax case**
  *

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -225,6 +225,7 @@ Would be a cmi5 defined xAPI statement with a verb display name of ‘completed�
 
 This document refers to properites in text descriptions  (ADD TO THIS)
 
+**Style Conventions**  
 This document uses the following style conventions:
 
 * **Back Ticks ( ` )** (rendered as “inline code”) for all literal names of verbs and properties 
@@ -235,13 +236,13 @@ This document uses the following style conventions:
 
 **Style Usage examples**
 * **Back Ticks ( ` )**
- * the ‘score’ property  
-    for `score` when….  
+	* the ‘score’ property  
+	for `score` when….  
 
 * **Double Quotes ( " )**
 	* the 'completed' statement  
 
-    the "completed" statement must
+	the "completed" statement must
 
 * **Literal syntax case**
  *
@@ -250,9 +251,9 @@ This document uses the following style conventions:
  * 
 
 * **All styles together**
-* The ‘fetch’ parameter contains a URL value that is used to….  
+	* The ‘fetch’ parameter contains a URL value that is used to….  
 
-> The `fetch` query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
+	> The `fetch` query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
 
 
 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -238,10 +238,10 @@ This document uses the following style conventions:
 * **Literal syntax case example. The actor object with an object type of agent:**  
 	The actor object with an objectType of Agent
 
-* **Section Titles with verb example. 	See [Section 9.3.1 Launched](#verbs_launched):** 	
+* **Section Titles with verb example. 	See Section 9.3.1 Launched:**  
 	9.3.1 Launched
 
-* **Section Titles with properties example. 	See [Section 9.5.4 Duration](#duration):**	 
+* **Section Titles with properties example. 	See Section 9.5.4 Duration:**  
 	9.5.4 Duration
 
 <a name="references"></a> 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -15,6 +15,7 @@
 
 * [__1.0 Overview__](#overview)
   * [1.1 Scope](#scope)
+  * [1.2 Document Style Conventions](#Document_Style_Conventions)
 * [__2.0 References__](#references)
 * [__3.0 Definitions__](#definitions)
   * [3.1 Abbreviations and Acronyms](#acronyms)
@@ -205,14 +206,14 @@ Other uses of the xAPI specification are outside of this scope.
 
 Uses of activities not explicitly defined above are outside of the scope of this specification.
 
-<a name="Document Style Conventions"></a>  
+<a name="Document_Style_Conventions"></a>  
 ## 1.2 Document Style Conventions
 
 The following is proposed language to express the document style conventions.  (e.g. a "how to read this document")
 
  **References to Statements**
 
-This document uses, as shorthand, specific vocabulary such as verbs in conjunction with the word "statement" (e.g., a "completed" statement). This shorthand refers to that statement meeting all requirements that would accompany the correct use of that concept. When using this shorthand with the word “the”, this means the cmi5 defined version of that statement with the verb’s display property. (see Section 7.1.3 Types of Statements for the definition of cmi5 defined)
+This document uses, as shorthand, specific vocabulary such as verbs in conjunction with the word "statement" (e.g., a "completed" statement). This shorthand refers to that statement meeting all requirements that would accompany the correct use of that concept. When using this shorthand with the word “the”, this means the cmi5 defined version of that statement with the verb’s display property. (see Section 7.1.3 Types of Statements (#type_statement_au) for the definition of cmi5 defined)
 
 For example:
 

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -205,6 +205,39 @@ Other uses of the xAPI specification are outside of this scope.
 
 Uses of activities not explicitly defined above are outside of the scope of this specification.
 
+<a name="Document Style Conventions"></a>  
+## 1.2 Document Style Conventions
+
+The following is proposed language to express the document style conventions.  (e.g. a "how to read this document")
+
+ **References to Statements**
+
+This document uses, as shorthand, specific vocabulary such as verbs in conjunction with the word "statement" (e.g., a "completed" statement). This shorthand refers to that statement meeting all requirements that would accompany the correct use of that concept. When using this shorthand with the word “the”, this means the cmi5 defined version of that statement with the verb’s display property. (see Section 7.1.3 Types of Statements for the definition of cmi5 defined)
+
+For example:
+
+> `the “completed” statement`
+
+Would be a cmi5 defined xAPI statement with a verb display name of ‘completed’ and a verb IRI of ‘http://adlnet.gov/expapi/verbs/completed’.  Similar conventions might be used for other xAPI properties.
+
+**References to Properties**
+
+This document refers to properites in text descriptions  (ADD TO THIS)
+
+This document uses the following style conventions:
+
+* **Back Ticks ( ` )** – (possibly rendered as “inline code”) for all literal names of verbs and properties – ‘completed’ verb
+ - do not use bold/italic styling on verb & properties in text descriptions (use back ticks instead)
+* **Double Quotes for shorthand** – the “completed” statement (as described in above)
+* **Literal syntax case** – When referring to verbs and properties the case will show as they appear in xAPI statements
+* **Section Titles with verbs/properties** – may use either Capitalized or Literal
+
+**Style Usage examples**
+* the ‘score’ property
+* for ‘score’ when….
+* The ‘fetch’ parameter contains a URL value that is used to….
+* The “fetch” URL = The shorthand Concept of 
+* The ‘fetch’ query parameter contains a URL value (the “fetch” URL) that is used by the AU to obtain an authorization token created and managed by the LMS. The authorization token is used by the AU being launched.
 
 <a name="references"></a> 
 # 2.0  References


### PR DESCRIPTION
This is my first draft at the section 1.2 Document Style Conventions.   This is the explanation of the document style conventions based on discussions in the working group on Jan 27, 2023 minutes. https://github.com/AICC/CMI-5_Spec_Current/wiki/CMI-5-Working-Group-Meeting-Minutes-–-January-27th%2C-2023

This also includes a reference to Section 1.2 in the Table of Contents.  Within it is a link to another section.

