### PR TITLE
Apply section 1.2 to section 10.2.1 to section 10.2.4

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1063,15 +1063,15 @@ The properties for the `LMS.LaunchData` document are described below.
 <a name="xapi_state_properties_contextTemplate"></a>
 ### 10.2.1 contextTemplate
 <table>
-  <tr><th align="right" nowrap>Description:</th><td>Context template for the AU being launched.</td></tr>
+  <tr><th align="right" nowrap>Description:</th><td><code>contextTemplate</code> for the AU being launched.</td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>Yes</td></tr>
-  <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST include a "contextTemplate" object and MUST include the following values:
-<ul><li>The value for session id placed in an "extensions" property with the id as defined in Section 9.6.3.1.</li>
-<li>The publisher id Activity as defined in Section 9.6.2.3 in the "contextActivities.grouping" list</li></ul>
-The LMS MAY place additional values in the "contextTemplate".</td></tr>
-  <tr><th align="right" nowrap>AU Usage:</th><td>The AU MUST get the "contextTemplate" value from the  <code>LMS.LaunchData</code> State document. The AU MUST NOT modify or delete the  <code>LMS.LaunchData</code> State document. The AU MUST use the contextTemplate as a template for the "context" property in all xAPI statements it sends to the LMS. While the AU MAY include additional values in the Context object of such statements, it MUST NOT overwrite any values provided in the contextTemplate. NOTE: this will include the session id specified by the LMS.</td></tr>
-  <tr><th align="right" nowrap>Data Type:</th><td>JSON Context object as defined in xAPI specification.</td></tr>
+  <tr><th align="right" nowrap>LMS Usage:</th><td>The LMS MUST include a <code>contextTemplate</code> object and MUST include the following values:
+<ul><li>The value for session id placed in an <code>extensions</code> object with the ID as defined in Section 9.6.3.1.</li>
+<li>The publisher ID Activity as defined in Section 9.6.2.3 in the <code>contextActivities.grouping</code> list</li></ul>
+The LMS MAY place additional values in the <code>contextTemplate</code>.</td></tr>
+  <tr><th align="right" nowrap>AU Usage:</th><td>The AU MUST get the <code>contextTemplate</code> value from the  <code>LMS.LaunchData</code> State document. The AU MUST NOT modify or delete the  <code>LMS.LaunchData</code> State document. The AU MUST use the <code>contextTemplate</code> as a template for the <code>context</code> property in all xAPI statements it sends to the LMS. While the AU MAY include additional values in the <code>context</code> object of such statements, it MUST NOT overwrite any values provided in the <code>contextTemplate</code>. NOTE: this will include the session ID specified by the LMS.</td></tr>
+  <tr><th align="right" nowrap>Data Type:</th><td>JSON <code>context</code> object as defined in xAPI specification.</td></tr>
 </table>
 
 <a name="xapi_state_properties_launchMode"></a>

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1078,9 +1078,9 @@ The LMS MAY place additional values in the <code>contextTemplate</code>.</td></t
 ### 10.2.2 launchMode
 <table>
   <tr><th align="right" nowrap>Description:</th><td>The launch mode determined by the LMS. There are three possible values:<br>
-      <ul><li>Normal<br>Indicates to the AU that satisfaction-related data MUST be recorded in the LMS using xAPI statements.</li>
-          <li>Browse<br>Indicates to the AU that satisfaction-related data MUST NOT be recorded in the LMS using xAPI statements. When Browse mode is used, the AU SHOULD provide a user experience that allows the user to "look around" without judgement.</li>
-          <li>Review<br>Indicates to the AU that satisfaction-related data MUST NOT be recorded in the LMS using xAPI statements. When Review mode is used, the AU SHOULD provide a user experience that allows the user to "revisit/review" already completed material.</li>
+      <ul><li><code>Normal</code><br>Indicates to the AU that satisfaction-related data MUST be recorded in the LMS using xAPI statements.</li>
+          <li><code>Browse</code><br>Indicates to the AU that satisfaction-related data MUST NOT be recorded in the LMS using xAPI statements. When Browse mode is used, the AU SHOULD provide a user experience that allows the user to "look around" without judgement.</li>
+          <li><code>Review</code><br>Indicates to the AU that satisfaction-related data MUST NOT be recorded in the LMS using xAPI statements. When Review mode is used, the AU SHOULD provide a user experience that allows the user to "revisit/review" already completed material.</li>
       </ul></td></tr>
   <tr><th align="right" nowrap>LMS Required:</th><td>Yes</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>Yes</td></tr>

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1110,11 +1110,11 @@ The LMS MAY place additional values in the <code>contextTemplate</code>.</td></t
 <a name="xapi_state_properties_masteryScore"></a>
 ### 10.2.4 masteryScore
 <table>
-  <tr><th align="right" nowrap>Description:</th><td>The <strong><em>masteryScore</em></strong> from the cmi5 Course Structure.</td></tr>
-  <tr><th align="right" nowrap>LMS Required:</th><td>The LMS MUST include a "masteryScore" in the State API document if the <strong><em>masteryScore</em></strong> was defined by the course designer in the Course Structure.</td></tr>
-  <tr><th align="right" nowrap>AU Required:</th><td>If the <strong><em>masteryScore</em></strong> is provided.</td></tr>
-  <tr><th align="right" nowrap>LMS Usage:</th><td>The <strong><em>masteryScore</em></strong> value written in the State API Document MAY be different than the one in the course structure (e.g. based on administrative rules defined by the LMS).</td></tr>
-  <tr><th align="right" nowrap>AU Usage:</th><td>If the AU issues "Passed" or "Failed" statements they MUST be based on the <strong><em>masteryScore</em></strong> if provided. (See Sections 9.3.4 and 9.3.5)</td></tr>
+  <tr><th align="right" nowrap>Description:</th><td>The <code>masteryScore</code> from the cmi5 Course Structure.</td></tr>
+  <tr><th align="right" nowrap>LMS Required:</th><td>The LMS MUST include a <code>masteryScore</code> in the <code>LMS.LaunchData</code> State document if the <code>masteryScore</code> was defined by the course designer in the Course Structure.</td></tr>
+  <tr><th align="right" nowrap>AU Required:</th><td>If the <code>masteryScore</code> is provided.</td></tr>
+  <tr><th align="right" nowrap>LMS Usage:</th><td>The <code>masteryScore</code> value written in the <code>LMS.LaunchData</code> State document MAY be different than the one in the course structure (e.g. based on administrative rules defined by the LMS).</td></tr>
+  <tr><th align="right" nowrap>AU Usage:</th><td>If the AU issues "passed" or "failed" statements they MUST be based on the <code>masteryScore</code> if provided. (See Sections 9.3.4 and 9.3.5)</td></tr>
   <tr><th align="right" nowrap>Data Type:</th><td>decimal</td></tr>
   <tr><th align="right" nowrap>Value Space:</th><td>Decimal value between 0 and 1 (inclusive) with up to 4 decimal places of precision.</td></tr>
   <tr><th align="right" nowrap>Sample Value:</th><td>0.75</td></tr>

--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -1097,11 +1097,12 @@ The LMS MAY place additional values in the <code>contextTemplate</code>.</td></t
 <a name="xapi_state_properties_launchParameters"></a>
 ### 10.2.3 launchParameters
 <table>
-  <tr><th align="right" nowrap>Description:</th><td>The <strong><em>launchParameters</em></strong> defined in the cmi5 Course Structure.</td></tr>
-  <tr><th align="right" nowrap>LMS Required:</th><td>The LMS MUST include the  <strong><em>launchParameters</em></strong> in the State API document if the <strong><em>launchParameters</em></strong> were defined by the course designer in the Course Structure.</td></tr>
+  <tr><th align="right" nowrap>Description:</th><td>The <code>launchParameters</code> defined in the cmi5 Course Structure.
+  </td></tr>
+  <tr><th align="right" nowrap>LMS Required:</th><td>The LMS MUST include the  <code>launchParameters</code> in the <code>LMS.LaunchData</code> State document if the <code>launchParameters</code> were defined by the course designer in the Course Structure.</td></tr>
   <tr><th align="right" nowrap>AU Required:</th><td>No</td></tr>
-  <tr><th align="right" nowrap>LMS Usage:</th><td>The <em>launchParameters</em> value written in the State API Document MAY be different than the one in the course structure (e.g. based on content vendor options that might be used by the LMS admin users).</td></tr>
-  <tr><th align="right" nowrap>AU Usage:</th><td>The AU SHOULD get the <strong><em>launchParameters</em></strong> value from the State API document if the launch parameters were defined in the Course Structure.</td></tr>
+  <tr><th align="right" nowrap>LMS Usage:</th><td>The <code>launchParameters</code> value written in the <code>LMS.LaunchData</code> State document MAY be different than the one in the course structure (e.g. based on content vendor options that might be used by the LMS admin users).</td></tr>
+  <tr><th align="right" nowrap>AU Usage:</th><td>The AU SHOULD get the <code>launchParameters</code> value from the <code>LMS.LaunchData</code> State document if the launch parameters were defined in the Course Structure.</td></tr>
   <tr><th align="right" nowrap>Data Type:</th><td>String</td></tr>
   <tr><th align="right" nowrap>Value Space:</th><td>Any string value</td></tr>
 </table>


### PR DESCRIPTION
I made the following changes:

- changes to Section 10.2.1 to Section 10.2.4 as per cmi5 Working Group meeting May 5, 2023.

- some further changes beyond the notes from the May 5, 2023 meeting as they were consistent
   with formatting in other Sections in the document which have already been reviewed.
   - **Section 10.2.4 masteryScore**
           - LMS Required:  changed  'State API Document' to 'LMS.LaunchData State document' 
           - AU required:  capitalized 'ID'
           
- I have a further question:
   - **Section 10.2.1 contextTemplate**
             - In the sub Section 'AU Usage:' should context 'property' in the first sentence of the sub section be context 'object'?

  `The AU MUST use the contextTemplate as a template for the context property in all xAPI statements it sends to the LMS. While the AU MAY include additional values in the context object of such statements, it MUST NOT overwrite any values provided in the contextTemplate.`
