### PR TITLE
Issue #801 Remove IFI from Section 9.2 Actor

### DIFF
--- a/cmi5_spec.md
+++ b/cmi5_spec.md
@@ -637,7 +637,7 @@ The AU MUST assign a statement `id` property in UUID format (as defined in the x
   
 <a name="actor" ></a>
 ## 9.2 Actor
-The `actor` property MUST be defined by the LMS. The`actor` property for all cmi5 defined statements MUST be of objectType `agent`. The Actor property MUST contain an `account` property (IFI) as defined in the xAPI specification.
+The `actor` property MUST be defined by the LMS. The`actor` property for all cmi5 defined statements MUST be of objectType `agent`. The Actor property MUST contain an `account` property as defined in the xAPI specification.
 
 <a name="verbs" ></a> 
 ## 9.3 Verbs  


### PR DESCRIPTION
The term Inverse Function Identifier (IFI) is in the xAPI specification and is defined there.  Per discussion at the Jul 21, 2023 working group meeting it was decided to remove the term rather than also define it in the cmi5 Specification Document. Issue #801